### PR TITLE
design: 마이페이지 구현

### DIFF
--- a/briefin/src/app/(CommonLayout)/mypage/page.tsx
+++ b/briefin/src/app/(CommonLayout)/mypage/page.tsx
@@ -1,3 +1,27 @@
-export default function page() {
-  return <main className="fonts-navBar pt-300pxr relative flex h-full w-full flex-col items-center">마이 페이지</main>;
+'use client';
+
+import { useState } from 'react';
+import MyPageHeader from '@/components/mypage/mypageheader';
+import MyPageTabs, { MyPageTab } from '@/components/mypage/mypagetabs';
+
+export default function MyPage() {
+  const [activeTab, setActiveTab] = useState<MyPageTab>('스크랩 뉴스');
+
+  const handleLogout = () => {
+    console.log('로그아웃');
+  };
+
+  return (
+    <div className="min-h-screen bg-surface-bg">
+      <MyPageHeader email="user@example.com" onLogout={handleLogout} />
+      <MyPageTabs activeTab={activeTab} onTabChange={setActiveTab} />
+
+      <div className="px-24pxr pt-28pxr">
+        {activeTab === '관심 기업' && <div>{/* 관심 기업 컨텐츠 */}</div>}
+        {activeTab === '스크랩 뉴스' && <div>{/* 스크랩 뉴스 컨텐츠 */}</div>}
+        {activeTab === '최근 본 뉴스' && <div>{/* 최근 본 뉴스 컨텐츠 */}</div>}
+        {activeTab === '계정 관리' && <div>{/* 계정 관리 컨텐츠 */}</div>}
+      </div>
+    </div>
+  );
 }

--- a/briefin/src/app/globals.css
+++ b/briefin/src/app/globals.css
@@ -13,13 +13,13 @@
 
   body {
     width: 100%;
-    min-height: 100dvh;
+    min-width: 1024px;
     height: 100dvh;
     margin: 0 auto;
-    background-color: #f7f8fa;
+    background-color: white;
     -ms-overflow-style: none;
     position: relative;
-    box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.08);
+    box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.1);
   }
 
   ::-webkit-scrollbar {

--- a/briefin/src/components/mypage/mypageheader.tsx
+++ b/briefin/src/components/mypage/mypageheader.tsx
@@ -1,0 +1,20 @@
+interface MyPageHeaderProps {
+  email?: string;
+  onLogout?: () => void;
+}
+
+export default function MyPageHeader({ email = 'user@example.com', onLogout }: MyPageHeaderProps) {
+  return (
+    <div className="flex items-start justify-between px-24pxr pt-36pxr pb-16pxr">
+      <div className="flex flex-col gap-4pxr">
+        <h1 className="fonts-heading2">마이페이지</h1>
+        <p className="text-[15px] text-text-muted">{email}</p>
+      </div>
+      <button
+        onClick={onLogout}
+        className="h-38pxr rounded-button border border-surface-border bg-surface-white px-16pxr text-[14px] font-bold text-text-secondary transition-colors hover:bg-surface-bg">
+        로그아웃
+      </button>
+    </div>
+  );
+}

--- a/briefin/src/components/mypage/mypagetabs.tsx
+++ b/briefin/src/components/mypage/mypagetabs.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+export type MyPageTab = '관심 기업' | '스크랩 뉴스' | '최근 본 뉴스' | '계정 관리';
+
+const TABS: MyPageTab[] = ['관심 기업', '스크랩 뉴스', '최근 본 뉴스', '계정 관리'];
+
+interface MyPageTabsProps {
+  activeTab: MyPageTab;
+  onTabChange: (tab: MyPageTab) => void;
+}
+
+export default function MyPageTabs({ activeTab, onTabChange }: MyPageTabsProps) {
+  return (
+    <div className="relative mx-24pxr flex border-b-2 border-surface-border">
+      {TABS.map((tab) => {
+        const isActive = tab === activeTab;
+        return (
+          <button
+            key={tab}
+            onClick={() => onTabChange(tab)}
+            className={`relative h-46pxr px-16pxr text-[14px] font-bold transition-colors ${
+              isActive
+                ? 'text-primary after:absolute after:bottom-[-2px] after:left-0 after:right-0 after:h-[2px] after:bg-primary'
+                : 'text-text-muted hover:text-text-secondary'
+            }`}>
+            {tab}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣ Issue Number
close #5

## 📝 변경사항

- `MyPageHeader` 컴포넌트 구현 (제목, 이메일, 로그아웃 버튼)
- `MyPageTabs` 컴포넌트 구현 (관심 기업 / 스크랩 뉴스 / 최근 본 뉴스 / 계정 관리 탭, 활성 탭 파란 언더라인)
- 마이페이지 `page.tsx` 탭 상태 관리 및 레이아웃 구성

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 마이페이지 접근 시 기본 탭이 `스크랩 뉴스`로 활성화되는지 확인
- [ ] 각 탭 클릭 시 활성 탭 스타일(파란 언더라인) 전환 확인
- [ ] 로그아웃 버튼 렌더링 확인
- [ ] 커스텀 컬러 토큰(`text-primary`, `bg-surface-bg` 등) 및 `pxr` 스페이싱 정상 적용 확인

### 🔍 주안점 & 리뷰 포인트

<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->
<!--
  - 예: 멀티 모듈 구조에서 의존성 주입 방식이 적절한지 봐주세요.
  - 예: Next.js App Router의 `params` 언래핑(unwrap) 처리가 올바른지 확인 부탁드립니다.
-->

### 🖼️ 스크린샷 / 테스트 결과

<!--
  (Optional)
  작업 결과 만들거나 변경된 화면 스크린샷
  테스트 수행 결과 스크린샷
-->

---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ]
- [ ]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 마이페이지에 탭 네비게이션 추가 (관심 기업, 스크랩 뉴스, 최근 본 뉴스, 계정 관리)
  * 사용자 정보 표시 및 로그아웃 기능이 포함된 헤더 추가

* **스타일**
  * 배경색 및 그림자 효과 업데이트
  * 전체 레이아웃 제약 조건 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->