### PR TITLE
design: 기업상세페이지 구현

### DIFF
--- a/briefin/src/app/(CommonLayout)/companies/[id]/page.tsx
+++ b/briefin/src/app/(CommonLayout)/companies/[id]/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import Tabs from '@/components/common/Tabs';
+import CompanyHero from '@/components/companies/CompanyHero';
+import AlertBanner from '@/components/common/AlertBanner';
+import PopularCompanyList from '@/components/common/PopularCompanyList';
+import { MOCK_COMPANY, MOCK_NEWS, MOCK_RELATED_COMPANIES } from '@/mocks/companyDetail';
+
+type CompanyDetailTab = '관련 뉴스' | '공시';
+const COMPANY_DETAIL_TABS: CompanyDetailTab[] = ['관련 뉴스', '공시'];
+
+export default function CompanyDetailPage() {
+  const [activeTab, setActiveTab] = useState<CompanyDetailTab>('관련 뉴스');
+
+  return (
+    <div className="min-h-screen bg-surface-bg pb-40pxr">
+
+      {/* 뒤로가기 */}
+      <div className="pt-20pxr sm:pt-28pxr md:pt-36pxr">
+        <Link
+          href="/companies"
+          className="inline-flex items-center gap-4pxr rounded-button border border-surface-border bg-surface-white px-12pxr py-8pxr text-[13px] font-bold text-text-secondary transition-colors hover:bg-surface-bg sm:px-14pxr sm:py-10pxr sm:text-[14px]">
+          ← 뉴스 목록으로
+        </Link>
+      </div>
+
+      {/* 히어로 */}
+      <div className="mt-14pxr sm:mt-18pxr md:mt-20pxr">
+        <CompanyHero {...MOCK_COMPANY} />
+      </div>
+
+      {/* 컨텐츠 — 모바일: 단일 컬럼 / 데스크톱: 좌우 2컬럼 */}
+      <div className="mt-20pxr flex flex-col gap-16pxr lg:flex-row lg:items-start lg:gap-24pxr">
+
+        {/* 좌: 탭 + 뉴스 목록 */}
+        <div className="min-w-0 flex-1">
+          <Tabs tabs={COMPANY_DETAIL_TABS} activeTab={activeTab} onTabChange={setActiveTab} />
+          <div className="mt-16pxr flex flex-col gap-14pxr">
+            {activeTab === '관련 뉴스' &&
+              MOCK_NEWS.map((news) => (
+                <div key={news.id}>{/* TODO: NewsCard 컴포넌트 연결 예정 */}</div>
+              ))}
+            {activeTab === '공시' && <div>{/* TODO: 공시 컨텐츠 */}</div>}
+          </div>
+        </div>
+
+        {/* 우: 사이드바 — 모바일에서는 탭 컨텐츠 아래 전체 너비 */}
+        <div className="flex w-full flex-col gap-14pxr lg:w-60">
+
+          <AlertBanner
+            title="🔔 공시 알림 받기"
+            description="이 기업의 새 공시·뉴스를 실시간으로 받아보세요."
+            buttonLabel="알림 설정하기"
+          />
+
+          <PopularCompanyList
+            title="관련 기업"
+            companies={MOCK_RELATED_COMPANIES}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/briefin/src/app/(CommonLayout)/mypage/page.tsx
+++ b/briefin/src/app/(CommonLayout)/mypage/page.tsx
@@ -18,7 +18,7 @@ export default function MyPage() {
   return (
     <div className="min-h-screen bg-surface-bg">
       <MyPageHeader email="user@example.com" onLogout={handleLogout} />
-      <Tabs tabs={MY_PAGE_TABS} activeTab={activeTab} onTabChange={setActiveTab} />
+      <Tabs tabs={MY_PAGE_TABS} activeTab={activeTab} onTabChange={setActiveTab} className="mx-24pxr" />
 
       <div className="px-24pxr pt-28pxr">
         {activeTab === '관심 기업' && <div>{/* 관심 기업 컨텐츠 */}</div>}

--- a/briefin/src/components/common/AlertBanner.tsx
+++ b/briefin/src/components/common/AlertBanner.tsx
@@ -1,0 +1,22 @@
+interface AlertBannerProps {
+  title: string;
+  description: string;
+  buttonLabel: string;
+  onButtonClick?: () => void;
+}
+
+export default function AlertBanner({ title, description, buttonLabel, onButtonClick }: AlertBannerProps) {
+  return (
+    <div
+      className="rounded-card p-24pxr md:p-28pxr"
+      style={{ background: 'linear-gradient(135deg, #2C4A8F 0%, #1A3270 100%)' }}>
+      <p className="text-[15px] font-black text-white">{title}</p>
+      <p className="mt-10pxr text-[13px] leading-relaxed text-white/85">{description}</p>
+      <button
+        onClick={onButtonClick}
+        className="mt-16pxr h-42pxr w-full rounded-button bg-surface-white text-[14px] font-bold text-primary transition-colors hover:bg-primary-light">
+        {buttonLabel}
+      </button>
+    </div>
+  );
+}

--- a/briefin/src/components/common/PopularCompanyList.tsx
+++ b/briefin/src/components/common/PopularCompanyList.tsx
@@ -1,0 +1,44 @@
+interface Company {
+  id: number;
+  name: string;
+  sector: string;
+  change: string;
+  isRise: boolean;
+  emoji: string;
+  bgColor: string;
+}
+
+interface PopularCompanyListProps {
+  title: string;
+  companies: Company[];
+  onCompanyClick?: (id: number) => void;
+}
+
+export default function PopularCompanyList({ title, companies, onCompanyClick }: PopularCompanyListProps) {
+  return (
+    <div className="rounded-card border border-surface-border bg-surface-white p-20pxr">
+      <p className="text-[15px] font-black text-text-primary">{title}</p>
+      <ul className="mt-8pxr divide-y divide-surface-border">
+        {companies.map((company) => (
+          <li
+            key={company.id}
+            onClick={() => onCompanyClick?.(company.id)}
+            className={`flex items-center gap-12pxr py-12pxr ${onCompanyClick ? 'cursor-pointer hover:opacity-70' : ''}`}>
+            <div className={`flex h-40pxr w-40pxr shrink-0 items-center justify-center rounded-button text-[18px] ${company.bgColor}`}>
+              {company.emoji}
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-[14px] font-bold text-text-primary">{company.name}</p>
+              <p className="fonts-caption">{company.sector}</p>
+            </div>
+            <p className={`shrink-0 text-[13px] font-bold ${company.isRise ? 'text-semantic-red' : 'text-semantic-neutral'}`}>
+              {company.change}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export type { Company };

--- a/briefin/src/components/common/Tabs.tsx
+++ b/briefin/src/components/common/Tabs.tsx
@@ -4,11 +4,12 @@ interface TabsProps<T extends string> {
   tabs: T[];
   activeTab: T;
   onTabChange: (tab: T) => void;
+  className?: string;
 }
 
-export default function Tabs<T extends string>({ tabs, activeTab, onTabChange }: TabsProps<T>) {
+export default function Tabs<T extends string>({ tabs, activeTab, onTabChange, className = '' }: TabsProps<T>) {
   return (
-    <div className="relative mx-24pxr flex border-b-2 border-surface-border">
+    <div className={`relative flex border-b-2 border-surface-border ${className}`}>
       {tabs.map((tab) => {
         const isActive = tab === activeTab;
         return (
@@ -17,7 +18,7 @@ export default function Tabs<T extends string>({ tabs, activeTab, onTabChange }:
             onClick={() => onTabChange(tab)}
             className={`relative h-46pxr px-16pxr text-[14px] font-bold transition-colors ${
               isActive
-                ? 'text-primary after:absolute after:bottom-[-2px] after:left-0 after:right-0 after:h-[2px] after:bg-primary'
+                ? 'text-primary after:absolute after:-bottom-0.5 after:left-0 after:right-0 after:h-0.5 after:bg-primary'
                 : 'text-text-muted hover:text-text-secondary'
             }`}>
             {tab}

--- a/briefin/src/components/companies/CompanyHero.tsx
+++ b/briefin/src/components/companies/CompanyHero.tsx
@@ -1,0 +1,55 @@
+interface StatChip {
+  label: string;
+  value: string;
+  unit?: string;
+  isRise?: boolean;
+  isFall?: boolean;
+}
+
+interface CompanyHeroProps {
+  industry: string;
+  name: string;
+  stats: StatChip[];
+  isWatchlisted?: boolean;
+  onToggleWatchlist?: () => void;
+}
+
+export default function CompanyHero({ industry, name, stats, isWatchlisted = false, onToggleWatchlist }: CompanyHeroProps) {
+  return (
+    <div
+      className="rounded-hero p-16pxr md:px-40pxr md:py-36pxr"
+      style={{ background: 'linear-gradient(135deg, #F5F0E8 0%, #E0D8C8 100%)' }}>
+
+      {/* 업종 + 관심 등록 */}
+      <div className="flex items-center justify-between gap-8pxr">
+        <p className="truncate text-[12px] font-bold text-primary-dark md:text-[14px]">{industry}</p>
+        <button
+          onClick={onToggleWatchlist}
+          className="shrink-0 rounded-button border border-surface-border bg-surface-white px-12pxr py-7pxr text-[12px] font-bold text-text-secondary transition-colors hover:bg-surface-bg md:px-16pxr md:py-10pxr md:text-[14px]">
+          {isWatchlisted ? '★ 관심 등록됨' : '☆ 관심 등록'}
+        </button>
+      </div>
+
+      {/* 기업명 */}
+      <h1 className="mt-10pxr text-[22px] font-black tracking-[-0.5px] text-text-primary md:mt-16pxr md:text-[32px] md:tracking-[-1px]">
+        {name}
+      </h1>
+
+      {/* 스탯 칩 — 모바일: 균등 분배 / 데스크톱: 컨텐츠 자연 너비 */}
+      <div className="mt-14pxr flex gap-8pxr md:mt-20pxr md:gap-12pxr">
+        {stats.map((stat) => (
+          <div key={stat.label} className="flex-1 rounded-summary bg-surface-white px-12pxr py-10pxr shadow-stat-chip md:flex-none md:px-20pxr md:py-14pxr">
+            <p className="fonts-micro text-center">{stat.label}</p>
+            <p
+              className={`mt-4pxr text-center text-[14px] font-black tracking-[-0.5px] md:mt-8pxr md:text-[20px] ${
+                stat.isRise ? 'text-semantic-red' : stat.isFall ? 'text-semantic-neutral' : 'text-text-primary'
+              }`}>
+              {stat.value}
+              {stat.unit && <span className="ml-1pxr text-[10px] font-medium md:text-[13px]">{stat.unit}</span>}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/briefin/src/mocks/companyDetail.ts
+++ b/briefin/src/mocks/companyDetail.ts
@@ -1,0 +1,48 @@
+export interface CompanyInfo {
+  industry: string;
+  name: string;
+  stats: {
+    label: string;
+    value: string;
+    unit?: string;
+    isRise?: boolean;
+    isFall?: boolean;
+  }[];
+}
+
+export interface NewsItem {
+  id: number;
+  source: string;
+  time: string;
+  title: string;
+}
+
+export interface RelatedCompany {
+  id: number;
+  name: string;
+  sector: string;
+  change: string;
+  isRise: boolean;
+  emoji: string;
+  bgColor: string;
+}
+
+export const MOCK_COMPANY: CompanyInfo = {
+  industry: '반도체 및 전자제품 제조',
+  name: '삼성전자',
+  stats: [
+    { label: '현재가', value: '62,400', unit: '원' },
+    { label: '등락률', value: '+1.3%', isRise: true },
+    { label: '시가총액', value: '372조' },
+  ],
+};
+
+export const MOCK_NEWS: NewsItem[] = [
+  { id: 1, source: '로이터', time: '오전 10:30', title: '삼성전자, 북미 최대 데이터센터와 NVMe SSD 공급 계약 체결' },
+  { id: 2, source: '한국경제', time: '2026.01.15', title: '삼성전자, CES 2026서 차세대 OLED 패널 공개' },
+];
+
+export const MOCK_RELATED_COMPANIES: RelatedCompany[] = [
+  { id: 1, name: 'SK하이닉스', sector: '반도체', change: '-0.4%', isRise: false, emoji: '💾', bgColor: 'bg-[#f0fdf4]' },
+  { id: 2, name: '삼성SDI', sector: '배터리', change: '+0.6%', isRise: true, emoji: '🔵', bgColor: 'bg-[#eff6ff]' },
+];


### PR DESCRIPTION
## #️⃣ Issue Number

close #17 

## 📝 변경사항

- 기업 상세 페이지(`/companies/[id]`) 구현
  - `CompanyHero`: 업종·기업명·스탯 칩(현재가·등락률·시가총액)·관심 등록 버튼
  - 관련 뉴스 / 공시 탭 전환 구조
  - 반응형 2컬럼 레이아웃 (모바일 단일 컬럼 → 데스크톱 좌우 분리)
- 공통 컴포넌트 추가
  - `AlertBanner`: 알림 유도 배너 (타이틀·설명·버튼 props)
  - `PopularCompanyList`: 기업 목록 위젯 (타이틀·companies·클릭 핸들러 props)
  - `Tabs`: 제네릭 타입 + `className` prop으로 범용 탭 컴포넌트
- Mock 데이터 분리 (`src/mocks/companyDetail.ts`)

### 🎯 핵심 변경 사항 (Key Changes)

- [x] `/companies/[id]` 접근 시 히어로 카드 정상 렌더링 확인
- [x] 스탯 칩 모바일(균등 분배) / 데스크톱(자연 너비) 레이아웃 확인
- [x] 관련 뉴스 / 공시 탭 전환 동작 확인
- [x] `AlertBanner`, `PopularCompanyList` 다른 페이지에서 재사용 가능한지 확인
- [x] 모바일·태블릿·데스크톱 반응형 레이아웃 확인


### 🔍 주안점 & 리뷰 포인트

<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->
<!--
  - 예: 멀티 모듈 구조에서 의존성 주입 방식이 적절한지 봐주세요.
  - 예: Next.js App Router의 `params` 언래핑(unwrap) 처리가 올바른지 확인 부탁드립니다.
-->

### 🖼️ 스크린샷 / 테스트 결과

<!--
  (Optional)
  작업 결과 만들거나 변경된 화면 스크린샷
  테스트 수행 결과 스크린샷
-->

---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ]
- [ ]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 회사 상세 페이지 추가 - 관련 뉴스와 공시 탭으로 정보 조회 가능
  * 인기 기업 목록 컴포넌트 추가로 관심 기업 빠른 확인
  * 회사 기본 정보 및 통계 카드 추가로 한눈에 주요 지표 파악
  * 중요 알림 배너 추가로 주요 소식 전달

* **스타일**
  * Tabs 컴포넌트 스타일링 옵션 강화 및 활성 탭 표시기 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->