### PR TITLE
design: feed 페이지 구현

### DIFF
--- a/briefin/src/app/(CommonLayout)/companies/[id]/page.tsx
+++ b/briefin/src/app/(CommonLayout)/companies/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import Tabs from '@/components/common/Tabs';
 import CompanyHero from '@/components/companies/CompanyHero';
+import NewsCard from '@/components/common/NewsCard';
 import AlertBanner from '@/components/common/AlertBanner';
 import PopularCompanyList from '@/components/common/PopularCompanyList';
 import { MOCK_COMPANY, MOCK_NEWS, MOCK_RELATED_COMPANIES } from '@/mocks/companyDetail';
@@ -40,14 +41,14 @@ export default function CompanyDetailPage() {
           <div className="mt-16pxr flex flex-col gap-14pxr">
             {activeTab === '관련 뉴스' &&
               MOCK_NEWS.map((news) => (
-                <div key={news.id}>{/* TODO: NewsCard 컴포넌트 연결 예정 */}</div>
+                <NewsCard key={news.id} news={news} />
               ))}
             {activeTab === '공시' && <div>{/* TODO: 공시 컨텐츠 */}</div>}
           </div>
         </div>
 
         {/* 우: 사이드바 — 모바일에서는 탭 컨텐츠 아래 전체 너비 */}
-        <div className="flex w-full flex-col gap-14pxr lg:w-60">
+        <div className="flex w-full flex-col gap-14pxr lg:w-96">
 
           <AlertBanner
             title="🔔 공시 알림 받기"

--- a/briefin/src/app/(CommonLayout)/feed/page.tsx
+++ b/briefin/src/app/(CommonLayout)/feed/page.tsx
@@ -1,5 +1,39 @@
-export default function page() {
+'use client';
+
+import NewsCard from '@/components/common/NewsCard';
+import AlertBanner from '@/components/common/AlertBanner';
+import PopularCompanyList from '@/components/common/PopularCompanyList';
+import { MOCK_FEED_NEWS, MOCK_WATCHLIST } from '@/mocks/feed';
+
+export default function FeedPage() {
   return (
-    <main className="fonts-navBar pt-300pxr relative flex h-full w-full flex-col items-center">내 피드 페이지</main>
+    <main className="min-h-screen bg-surface-bg">
+      {/* Header */}
+      <div className="px-24pxr pb-16pxr pt-36pxr">
+        <h1 className="fonts-heading2">내 피드</h1>
+        <p className="mt-4pxr text-[14px] text-text-muted">관심 등록한 기업의 소식만 모았어요</p>
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-col gap-16pxr px-24pxr pb-40pxr lg:flex-row lg:items-start">
+        {/* Left: news list */}
+        <div className="flex flex-1 flex-col gap-14pxr">
+          {MOCK_FEED_NEWS.map((news) => (
+            <NewsCard key={news.id} news={news} />
+          ))}
+        </div>
+
+        {/* Right sidebar */}
+        <div className="flex flex-col gap-16pxr lg:w-96 lg:shrink-0">
+          <AlertBanner
+            title="관심 기업을 더 추가해보세요"
+            description="더 많은 기업을 등록할수록 내 피드가 풍성해져요."
+            buttonLabel="🏢 관련 기업 추가하기"
+          />
+          <PopularCompanyList title="👀 내 관심 기업" companies={MOCK_WATCHLIST} />
+          <button className="text-[13px] font-bold text-text-muted hover:text-text-primary">관심 기업 관리 →</button>
+        </div>
+      </div>
+    </main>
   );
 }

--- a/briefin/src/app/(CommonLayout)/news/page.tsx
+++ b/briefin/src/app/(CommonLayout)/news/page.tsx
@@ -6,11 +6,16 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ c
   const { category = 'all' } = await searchParams;
 
   return (
-    <main className="flex flex-col gap-22pxr bg-surface-bg">
+    <main className="min-h-screen bg-surface-bg">
       <TickerNav />
-      <div className="flex">
-        <NewsList category={category} />
-        <section className="flex flex-col">
+      <div className="flex flex-col gap-16pxr px-24pxr pb-40pxr pt-22pxr lg:flex-row lg:items-start">
+        {/* Left: news list */}
+        <div className="flex flex-1 flex-col gap-14pxr">
+          <NewsList category={category} />
+        </div>
+
+        {/* Right sidebar */}
+        <section className="flex flex-col gap-16pxr lg:w-96 lg:shrink-0">
           <AlertBanner
             title="🔔 공시 알림 받기"
             description="이 기업의 새 공시·뉴스를 실시간으로 받아보세요."

--- a/briefin/src/mocks/companyDetail.ts
+++ b/briefin/src/mocks/companyDetail.ts
@@ -1,3 +1,5 @@
+import { NewsItem } from '@/types/news';
+
 export interface CompanyInfo {
   industry: string;
   name: string;
@@ -10,12 +12,6 @@ export interface CompanyInfo {
   }[];
 }
 
-export interface NewsItem {
-  id: number;
-  source: string;
-  time: string;
-  title: string;
-}
 
 export interface RelatedCompany {
   id: number;
@@ -38,8 +34,8 @@ export const MOCK_COMPANY: CompanyInfo = {
 };
 
 export const MOCK_NEWS: NewsItem[] = [
-  { id: 1, source: '로이터', time: '오전 10:30', title: '삼성전자, 북미 최대 데이터센터와 NVMe SSD 공급 계약 체결' },
-  { id: 2, source: '한국경제', time: '2026.01.15', title: '삼성전자, CES 2026서 차세대 OLED 패널 공개' },
+  { id: 'company-news-1', source: '로이터', time: '오전 10:30', title: '삼성전자, 북미 최대 데이터센터와 NVMe SSD 공급 계약 체결', categories: ['관심기업'], companies: ['삼성전자'] },
+  { id: 'company-news-2', source: '한국경제', time: '2026.01.15', title: '삼성전자, CES 2026서 차세대 OLED 패널 공개', categories: ['관심기업'], companies: ['삼성전자'] },
 ];
 
 export const MOCK_RELATED_COMPANIES: RelatedCompany[] = [

--- a/briefin/src/mocks/feed.ts
+++ b/briefin/src/mocks/feed.ts
@@ -1,0 +1,27 @@
+import { NewsItem } from '@/types/news';
+import { Company } from '@/components/common/PopularCompanyList';
+
+export const MOCK_FEED_NEWS: NewsItem[] = [
+  {
+    id: 'feed-1',
+    source: '삼성전자',
+    time: '3시간 전',
+    title: '삼성전자, 북미 데이터센터와 NVMe SSD 공급 계약 체결',
+    summary: ['향후 2년간 안정적인 매출처 확보', '고부가가치 제품군 확대로 수익성 개선 기대'],
+    categories: ['관심기업'],
+    companies: [],
+  },
+  {
+    id: 'feed-2',
+    source: '현대차',
+    time: '5시간 전',
+    title: '현대차, 자율주행 소프트웨어 업데이트 발표',
+    categories: ['관심기업'],
+    companies: [],
+  },
+];
+
+export const MOCK_WATCHLIST: Company[] = [
+  { id: 1, name: '삼성전자', sector: '반도체 · 전자', change: '+1.3%', isRise: true, emoji: '📱', bgColor: 'bg-[#eff6ff]' },
+  { id: 2, name: '현대자동차', sector: '자동차', change: '+0.8%', isRise: true, emoji: '🚗', bgColor: 'bg-[#fff7ed]' },
+];


### PR DESCRIPTION
## #️⃣ Issue Number
close #24 

## 📝 변경사항

내 피드 페이지(/feed) 신규 구현
관심 기업 뉴스 목록 + 우측 사이드바(AlertBanner, 관심 기업 리스트) 2컬럼 레이아웃
모바일: 단일 컬럼 → 데스크톱(lg:): 좌우 2컬럼 반응형
뉴스 페이지(/news) 레이아웃 정비
기존 플레이스홀더 제거, 실제 NewsList + AlertBanner 사이드바 구조로 교체
피드 페이지와 동일한 레이아웃 구조 통일
기업 상세 페이지(/companies/[id]) 뉴스 카드 연결
TODO 플레이스홀더 제거, NewsCard 컴포넌트 실제 연결
mocks/companyDetail.ts의 NewsItem 타입 충돌 해결 (id: number → @/types/news의 NewsItem 재사용)
사이드바 너비 뉴스/피드/기업상세 페이지 lg:w-96으로 통일

### 🎯 핵심 변경 사항 (Key Changes)

 /feed 접속 시 뉴스 카드 목록 + 우측 알림/관심기업 사이드바 정상 렌더링
 /news 접속 시 TickerNav + 뉴스 목록 + 우측 AlertBanner 정상 렌더링
 /companies/[id] 접속 시 관련 뉴스 탭에 NewsCard 정상 표시
 모바일 화면에서 사이드바가 뉴스 목록 아래로 내려가는지 확인
 TypeScript 에러 없음 확인

### 🔍 주안점 & 리뷰 포인트

<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->
<!--
  - 예: 멀티 모듈 구조에서 의존성 주입 방식이 적절한지 봐주세요.
  - 예: Next.js App Router의 `params` 언래핑(unwrap) 처리가 올바른지 확인 부탁드립니다.
-->

### 🖼️ 스크린샷 / 테스트 결과

<!--
  (Optional)
  작업 결과 만들거나 변경된 화면 스크린샷
  테스트 수행 결과 스크린샷
-->

---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ]
- [ ]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 피드 페이지에 뉴스, 알림, 인기 기업 정보를 한눈에 보는 새로운 레이아웃 추가
  * 뉴스 페이지에 알림 배너를 포함한 사이드바 추가

* **개선 사항**
  * 전사 페이지의 관련 뉴스 섹션 UI 개선
  * 뉴스 항목 표시 형식 통일 및 카테고리 정보 추가
  * 페이지 레이아웃 구조 최적화로 정보 가시성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->