### PR TITLE
공시페이지 뷰 구현

### DIFF
--- a/briefin/src/app/(CommonLayout)/companies/[id]/page.tsx
+++ b/briefin/src/app/(CommonLayout)/companies/[id]/page.tsx
@@ -7,7 +7,9 @@ import CompanyHero from '@/components/companies/CompanyHero';
 import NewsCard from '@/components/common/NewsCard';
 import AlertBanner from '@/components/common/AlertBanner';
 import PopularCompanyList from '@/components/common/PopularCompanyList';
+import DisclosureList from '@/components/disclosure/DisclosureList';
 import { MOCK_COMPANY, MOCK_NEWS, MOCK_RELATED_COMPANIES } from '@/mocks/companyDetail';
+import { MOCK_COMPANY_DISCLOSURES } from '@/mocks/disclosureDetail';
 
 type CompanyDetailTab = '관련 뉴스' | '공시';
 const COMPANY_DETAIL_TABS: CompanyDetailTab[] = ['관련 뉴스', '공시'];
@@ -43,7 +45,9 @@ export default function CompanyDetailPage() {
               MOCK_NEWS.map((news) => (
                 <NewsCard key={news.id} news={news} />
               ))}
-            {activeTab === '공시' && <div>{/* TODO: 공시 컨텐츠 */}</div>}
+            {activeTab === '공시' && (
+              <DisclosureList items={MOCK_COMPANY_DISCLOSURES} />
+            )}
           </div>
         </div>
 

--- a/briefin/src/app/(CommonLayout)/disclosure/page.tsx
+++ b/briefin/src/app/(CommonLayout)/disclosure/page.tsx
@@ -1,3 +1,34 @@
-export default function page() {
-  return <main className="fonts-navBar pt-300pxr relative flex h-full w-full flex-col items-center">공시 페이지</main>;
+import Link from 'next/link';
+import DisclosureList from '@/components/disclosure/DisclosureList';
+import AlertBanner from '@/components/common/AlertBanner';
+import { MOCK_COMPANY_DISCLOSURES } from '@/mocks/disclosureDetail';
+
+export default function DisclosurePage() {
+  return (
+    <div className="min-h-screen bg-surface-bg pb-40pxr">
+      <div className="pt-20pxr sm:pt-28pxr md:pt-36pxr">
+        <Link
+          href="/companies"
+          className="inline-flex items-center gap-4pxr rounded-button border border-surface-border bg-surface-white px-12pxr py-8pxr text-[13px] font-bold text-text-secondary transition-colors hover:bg-surface-bg sm:px-14pxr sm:py-10pxr sm:text-[14px]"
+        >
+          ← 목록으로
+        </Link>
+      </div>
+
+      <h1 className="mt-20pxr fonts-heading2 text-text-primary">공시</h1>
+
+      <div className="mt-20pxr flex flex-col gap-16pxr lg:flex-row lg:items-start lg:gap-24pxr">
+        <div className="min-w-0 flex-1">
+          <DisclosureList items={MOCK_COMPANY_DISCLOSURES} />
+        </div>
+        <aside className="flex w-full flex-col gap-14pxr lg:w-96 lg:shrink-0">
+          <AlertBanner
+            title="🔔 공시 알림 받기"
+            description="관심 기업의 새 공시를 실시간으로 받아보세요."
+            buttonLabel="알림 설정하기"
+          />
+        </aside>
+      </div>
+    </div>
+  );
 }

--- a/briefin/src/app/(CommonLayout)/disclosures/[id]/page.tsx
+++ b/briefin/src/app/(CommonLayout)/disclosures/[id]/page.tsx
@@ -1,0 +1,132 @@
+import Link from 'next/link';
+import DisclosureHeader from '@/components/disclosure/disclosure-header';
+import DisclosureSummary from '@/components/disclosure/disclosure-summary';
+import DisclosureDetails from '@/components/disclosure/disclosure-details';
+import DisclosureSidebar from '@/components/disclosure/disclosure-sidebar';
+import { MOCK_DISCLOSURE_DETAIL, MOCK_RECENT_DISCLOSURES } from '@/mocks/disclosureDetail';
+import type { DisclosureDetail } from '@/types/disclosure';
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+async function getDisclosure(id: string): Promise<DisclosureDetail | null> {
+  // TODO: API 연동 시 fetch로 교체
+  if (id === MOCK_DISCLOSURE_DETAIL.id || id === '2026-03-00412') {
+    return MOCK_DISCLOSURE_DETAIL;
+  }
+  return null;
+}
+
+export default async function DisclosureDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const data = await getDisclosure(id);
+
+  if (!data) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-16pxr">
+        <p className="fonts-body text-text-secondary">해당 공시를 찾을 수 없습니다.</p>
+        <Link
+          href="/disclosure"
+          className="rounded-button border border-surface-border bg-surface-white px-14pxr py-10pxr text-[14px] font-bold text-text-secondary transition-colors hover:bg-surface-bg"
+        >
+          ← 공시 목록으로
+        </Link>
+      </div>
+    );
+  }
+
+  const {
+    summaryPoints,
+    description,
+    details,
+    descriptionAfterTable,
+    url,
+    documentUrl,
+    relatedCompanyNames,
+    companyName,
+  } = data;
+
+  return (
+    <div className="min-h-screen bg-surface-bg pb-40pxr">
+      <div className="pt-20pxr sm:pt-28pxr md:pt-36pxr">
+        <Link
+          href="/disclosure"
+          className="inline-flex items-center gap-4pxr rounded-button border border-surface-border bg-surface-white px-12pxr py-8pxr text-[13px] font-bold text-text-secondary transition-colors hover:bg-surface-bg sm:px-14pxr sm:py-10pxr sm:text-[14px]"
+        >
+          ← 공시 목록으로
+        </Link>
+      </div>
+
+      <div className="mt-14pxr flex flex-col gap-16pxr lg:flex-row lg:items-start lg:gap-24pxr">
+        <article className="min-w-0 flex-1 rounded-card border border-surface-border bg-surface-white p-24pxr shadow-hero-card sm:p-32pxr">
+          <DisclosureHeader
+            data={{
+              category: data.category,
+              date: data.date,
+              source: data.source,
+              title: data.title,
+              companyName: data.companyName,
+              reportNumber: data.reportNumber,
+            }}
+          />
+
+          <div className="mt-20pxr">
+            <DisclosureSummary summaryPoints={summaryPoints} />
+          </div>
+
+          <p className="fonts-body mt-20pxr text-text-secondary">{description}</p>
+
+          <div className="mt-20pxr">
+            <DisclosureDetails details={details} />
+          </div>
+
+          {descriptionAfterTable && (
+            <p className="fonts-body mt-20pxr text-text-secondary">{descriptionAfterTable}</p>
+          )}
+
+          <div className="mt-24pxr border-t border-surface-border pt-20pxr flex flex-wrap items-center gap-12pxr">
+            <a
+              href={documentUrl ?? url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-button border border-surface-border bg-surface-white px-20pxr py-12pxr text-[13px] font-bold text-text-secondary transition-colors hover:bg-surface-bg"
+            >
+              📄 원본 보고서 보기 (DART)
+            </a>
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-button border border-surface-border bg-surface-white px-20pxr py-12pxr text-[13px] font-bold text-text-secondary transition-colors hover:bg-surface-bg"
+            >
+              🔗 원문 공시 바로가기
+            </a>
+          </div>
+
+          {relatedCompanyNames && relatedCompanyNames.length > 0 && (
+            <div className="mt-24pxr">
+              <p className="fonts-caption mb-8pxr font-bold text-text-muted">관련 기업</p>
+              <div className="flex flex-wrap gap-8pxr">
+                {relatedCompanyNames.map((name) => (
+                  <Link
+                    key={name}
+                    href="/companies"
+                    className="rounded-badge bg-surface-muted px-14pxr py-8pxr text-[13px] font-bold text-text-secondary transition-colors hover:bg-surface-border"
+                  >
+                    📱 {name}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+        </article>
+
+        <DisclosureSidebar
+          recentDisclosures={MOCK_RECENT_DISCLOSURES}
+          companyName={companyName ? companyName.replace(/\s*주식회사\s*$/, '') : undefined}
+        />
+      </div>
+    </div>
+  );
+}

--- a/briefin/src/components/disclosure/DisclosureList.tsx
+++ b/briefin/src/components/disclosure/DisclosureList.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link';
+import type { DisclosureListItem } from '@/types/disclosure';
+
+interface DisclosureListProps {
+  items: DisclosureListItem[];
+  sourceLabel?: string;
+}
+
+function CategoryBadge({ category }: { category: string }) {
+  const isHighlight = category === '공급계약';
+  return (
+    <span
+      className={`shrink-0 rounded-badge px-10pxr py-4pxr text-[12px] font-bold ${
+        isHighlight ? 'bg-primary-light text-primary-dark' : 'bg-surface-muted text-text-secondary'
+      }`}
+    >
+      {category}
+    </span>
+  );
+}
+
+export default function DisclosureList({
+  items,
+  sourceLabel = 'DART 공시',
+}: DisclosureListProps) {
+  return (
+    <div className="rounded-card border border-surface-border bg-surface-white overflow-hidden shadow-hero-card">
+      <ul className="divide-y divide-surface-border">
+        {items.map((item) => (
+          <li key={item.id}>
+            <Link
+              href={`/disclosures/${item.id}`}
+              className="flex items-center gap-12pxr px-22pxr py-20pxr transition-colors hover:bg-surface-bg"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="line-clamp-2 text-[14px] font-bold text-text-primary">
+                  {item.title}
+                </p>
+                <p className="fonts-caption mt-4pxr">
+                  {item.date} · {sourceLabel}
+                </p>
+              </div>
+              <CategoryBadge category={item.category} />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/briefin/src/components/disclosure/disclosure-details.tsx
+++ b/briefin/src/components/disclosure/disclosure-details.tsx
@@ -1,0 +1,44 @@
+import type { DisclosureDetail } from '@/types/disclosure';
+
+interface DisclosureDetailsProps {
+  details: DisclosureDetail['details'];
+}
+
+const ROWS: { key: keyof DisclosureDetail['details']; label: string; highlight?: boolean }[] = [
+  { key: 'partner', label: '계약 상대방' },
+  { key: 'content', label: '계약 내용' },
+  { key: 'amount', label: '계약 금액', highlight: true },
+  { key: 'period', label: '계약 기간' },
+  { key: 'ratio', label: '매출액 대비' },
+  { key: 'reportType', label: '공시 구분' },
+];
+
+export default function DisclosureDetails({ details }: DisclosureDetailsProps) {
+  return (
+    <div className="rounded-summary bg-surface-bg p-20pxr">
+      <dl className="space-y-0">
+        {ROWS.map(({ key, label, highlight }) => {
+          const value = details[key as keyof typeof details];
+          if (value == null) return null;
+          return (
+            <div
+              key={key}
+              className="flex border-b border-surface-border py-14pxr first:pt-0 last:border-b-0 last:pb-0"
+            >
+              <dt className="w-[140px] shrink-0 text-[14px] font-bold leading-7 text-text-muted">
+                {label}
+              </dt>
+              <dd
+                className={`min-w-0 flex-1 text-[14px] leading-7 ${
+                  highlight ? 'font-bold text-primary' : 'font-normal text-text-secondary'
+                }`}
+              >
+                {value}
+              </dd>
+            </div>
+          );
+        })}
+      </dl>
+    </div>
+  );
+}

--- a/briefin/src/components/disclosure/disclosure-header.tsx
+++ b/briefin/src/components/disclosure/disclosure-header.tsx
@@ -1,0 +1,37 @@
+import type { DisclosureDetail } from '@/types/disclosure';
+
+interface DisclosureHeaderProps {
+  data: Pick<
+    DisclosureDetail,
+    'category' | 'date' | 'source' | 'title' | 'companyName' | 'reportNumber'
+  >;
+}
+
+export default function DisclosureHeader({
+  data: { category, date, source, title, companyName, reportNumber },
+}: DisclosureHeaderProps) {
+  const subLine = [companyName, reportNumber && `공시번호 ${reportNumber}`]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    <header className="space-y-12pxr">
+      <div className="flex flex-wrap items-center gap-8pxr">
+        <span className="rounded-badge bg-primary-light px-10pxr py-4pxr text-[10px] font-black tracking-wider text-primary-dark">
+          📋 DART 공시
+        </span>
+        <span className="rounded-badge bg-primary-light px-10pxr py-4pxr text-[11px] font-bold text-primary-dark">
+          {category}
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-16pxr fonts-caption text-text-muted">
+        {source && <span>{source}</span>}
+        <span>{date}</span>
+      </div>
+      <h1 className="fonts-heading3 text-text-primary">{title}</h1>
+      {subLine && (
+        <p className="text-[14px] font-normal text-text-muted">{subLine}</p>
+      )}
+    </header>
+  );
+}

--- a/briefin/src/components/disclosure/disclosure-sidebar.tsx
+++ b/briefin/src/components/disclosure/disclosure-sidebar.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link';
+import AlertBanner from '@/components/common/AlertBanner';
+import type { DisclosureListItem } from '@/types/disclosure';
+
+interface DisclosureSidebarProps {
+  recentDisclosures: DisclosureListItem[];
+  companyName?: string;
+  onAlertClick?: () => void;
+}
+
+export default function DisclosureSidebar({
+  recentDisclosures,
+  companyName = '이 기업',
+  onAlertClick,
+}: DisclosureSidebarProps) {
+  return (
+    <aside className="flex w-full flex-col gap-20pxr lg:w-[340px] lg:shrink-0">
+      <AlertBanner
+        title="🔔 공시 알림 받기"
+        description={`${companyName}의 새 공시가 올라오면 즉시 알려드려요.`}
+        buttonLabel="알림 설정하기"
+        onButtonClick={onAlertClick}
+      />
+      <div className="rounded-card border border-surface-border bg-surface-white overflow-hidden">
+        <h2 className="border-b border-surface-border px-22pxr py-16pxr text-[13px] font-black text-text-primary">
+          📋 최근 공시
+        </h2>
+        <ul className="divide-y divide-surface-border">
+          {recentDisclosures.map((item) => (
+            <li key={item.id}>
+              <Link
+                href={`/disclosures/${item.id}`}
+                className="block px-22pxr py-16pxr transition-colors hover:bg-surface-bg"
+              >
+                <p className="line-clamp-2 text-[14px] font-bold text-text-primary">
+                  {item.title}
+                </p>
+                <p className="fonts-caption mt-4pxr">
+                  {item.date} · {item.category}
+                </p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  );
+}

--- a/briefin/src/components/disclosure/disclosure-summary.tsx
+++ b/briefin/src/components/disclosure/disclosure-summary.tsx
@@ -1,0 +1,20 @@
+import type { DisclosureDetail } from '@/types/disclosure';
+
+interface DisclosureSummaryProps {
+  summaryPoints: DisclosureDetail['summaryPoints'];
+}
+
+export default function DisclosureSummary({ summaryPoints }: DisclosureSummaryProps) {
+  return (
+    <div className="rounded-summary bg-primary-light p-18pxr">
+      <ul className="space-y-12pxr">
+        {summaryPoints.map((point, i) => (
+          <li key={i} className="flex gap-8pxr text-[13px] leading-[19.5px] text-primary-dark">
+            <span className="shrink-0 font-black">✓</span>
+            <span className="font-normal">{point}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/briefin/src/mocks/disclosureDetail.ts
+++ b/briefin/src/mocks/disclosureDetail.ts
@@ -1,0 +1,80 @@
+import type { DisclosureDetail, DisclosureListItem } from '@/types/disclosure';
+
+export const MOCK_DISCLOSURE_DETAIL: DisclosureDetail = {
+  id: '2026-03-00412',
+  title: '주요사항보고서 (공급계약 체결)',
+  category: '공급계약',
+  date: '2026.03.13 오전 09:05',
+  source: '금융감독원 전자공시',
+  reportNumber: '2026-03-00412',
+  companyName: '삼성전자 주식회사',
+  summaryPoints: [
+    '북미 최대 데이터센터 운영사와 NVMe SSD 대규모 공급 계약 체결',
+    '계약 기간 2년, 총 계약 금액 약 1조 2,400억 원 규모',
+    '고부가가치 엔터프라이즈 SSD 제품군 중심 공급, 수익성 개선 기대',
+  ],
+  description:
+    '당사는 2026년 3월 13일 북미 소재 데이터센터 운영사와 NVMe SSD 공급에 관한 계약을 체결하였기에 아래와 같이 공시합니다.',
+  details: {
+    partner: '북미 데이터센터 운영사 (비공개)',
+    content: 'NVMe SSD 제품 공급',
+    amount: '1,240,000,000,000원 (약 1조 2,400억)',
+    period: '2026.03.13 ~ 2028.03.12 (2년)',
+    ratio: '약 3.2% (2024년 연결 매출 기준)',
+    reportType: '주요사항보고서',
+  },
+  descriptionAfterTable:
+    '본 계약은 당사의 엔터프라이즈 SSD 사업 확대 전략의 일환으로, 고부가가치 제품군 중심의 B2B 공급 채널을 강화하기 위한 목적으로 체결되었습니다. 계약 상대방의 요청에 따라 구체적인 사명은 비공개로 처리됩니다.',
+  url: 'https://dart.fss.or.kr',
+  documentUrl: 'https://dart.fss.or.kr/dsaf001/main.do',
+  relatedCompanyNames: ['삼성전자'],
+};
+
+export const MOCK_RECENT_DISCLOSURES: DisclosureListItem[] = [
+  {
+    id: '1',
+    title: '연결재무제표 기준 영업(잠정)실적 공시',
+    date: '2026.02.28',
+    category: 'DART 공시',
+  },
+  {
+    id: '2',
+    title: '사업보고서 (제56기)',
+    date: '2026.01.30',
+    category: 'DART 공시',
+  },
+  {
+    id: '3',
+    title: '배당결정 공시 – 보통주 1주당 500원',
+    date: '2026.01.20',
+    category: 'DART 공시',
+  },
+];
+
+/** 기업 상세 공시 탭용 목록 (Figma 순서·배지 반영) */
+export const MOCK_COMPANY_DISCLOSURES: DisclosureListItem[] = [
+  {
+    id: '2026-03-00412',
+    title: '주요사항보고서 (공급계약 체결)',
+    date: '2026.03.13',
+    category: '공급계약',
+  },
+  {
+    id: '1',
+    title: '연결재무제표 기준 영업(잠정)실적 공시',
+    date: '2026.02.28',
+    category: '실적발표',
+  },
+  {
+    id: '2',
+    title: '사업보고서 (제56기)',
+    date: '2026.01.30',
+    category: '보고서',
+  },
+  {
+    id: '3',
+    title: '배당결정 공시 – 보통주 1주당 500원',
+    date: '2026.01.20',
+    category: '배당',
+  },
+];

--- a/briefin/src/types/disclosure.ts
+++ b/briefin/src/types/disclosure.ts
@@ -1,0 +1,30 @@
+export type DisclosureDetail = {
+  id: string;
+  title: string;
+  category: string;
+  date: string;
+  source?: string;
+  reportNumber?: string;
+  companyName?: string;
+  summaryPoints: string[];
+  description: string;
+  details: {
+    partner: string;
+    content: string;
+    amount: string;
+    period: string;
+    ratio: string;
+    reportType?: string;
+  };
+  descriptionAfterTable?: string;
+  url: string;
+  documentUrl?: string;
+  relatedCompanyNames?: string[];
+};
+
+export type DisclosureListItem = {
+  id: string;
+  title: string;
+  date: string;
+  category: string;
+};


### PR DESCRIPTION
## #️⃣ Issue Number

#30

## 📝 변경사항

공시 목록·상세 페이지 및 기업 상세 공시 탭을 추가했습니다.  
Figma 디자인과 프로젝트 디자인 토큰(Tailwind, globals.css)에 맞춰 구현했으며, 이후 API 연동을 고려해 타입·더미 데이터를 분리해 두었습니다.

### 🎯 핵심 변경 사항 (Key Changes)

- [x] 공시 상세 페이지 (`/disclosures/[id]`) – 메인 카드(헤더·요약·본문·상세 테이블·버튼·관련 기업) + 우측 사이드(공시 알림, 최근 공시 리스트)
- [x] 공시 목록 페이지 (`/disclosure`) – 공시 리스트 카드 + 공시 알림 배너
- [x] 기업 상세 페이지 공시 탭 – 해당 기업 공시 목록 카드 + 기존 사이드바(알림·관련 기업)
- [x] 공시 관련 타입·목 데이터 분리 (`types/disclosure.ts`, `mocks/disclosureDetail.ts`)
- [x] 재사용 컴포넌트: `DisclosureList`, `DisclosureHeader`, `DisclosureSummary`, `DisclosureDetails`, `DisclosureSidebar`

### 🔍 주안점 & 리뷰 포인트

- Next.js App Router 기준 `params`는 `Promise<{ id: string }>`로 처리했는지 확인 부탁드립니다.
- 공시 상세 데이터는 `getDisclosure(id)`에서 목 데이터 반환 중이며, 추후 API로 교체 가능한 구조인지 한 번만 봐주시면 좋겠습니다.

### 🖼️ 스크린샷 / 테스트 결과

<!-- 스크린샷 첨부 시 여기에 링크 또는 이미지 -->

- `/disclosure` – 공시 목록
- `/disclosures/2026-03-00412` – 공시 상세
- `/companies/[id]` → 공시 탭 – 기업별 공시 목록

---

## 🛠️ PR 유형

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] 공시 상세/목록 API 연동 (`getDisclosure`, 목록 API)
- [ ] 공시 알림 설정 기능 연동 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **공시 정보 조회 기능 추가**
  * 공시 목록 페이지 및 상세 조회 페이지 구현
  * 공시 요약, 세부 사항, 관련 기업 정보 표시
  * 회사 상세 페이지에 공시 정보 통합

<!-- end of auto-generated comment: release notes by coderabbit.ai -->