### PR TITLE
feat: 관심기업 페이지로 리다이렉트

### DIFF
--- a/briefin/src/app/(CommonLayout)/feed/page.tsx
+++ b/briefin/src/app/(CommonLayout)/feed/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import NewsCard from '@/components/news/NewsCard';
 import AlertBanner from '@/components/common/AlertBanner';
 import PopularCompanyList from '@/components/common/PopularCompanyList';
@@ -31,7 +32,11 @@ export default function FeedPage() {
             buttonLabel="🏢 관련 기업 추가하기"
           />
           <PopularCompanyList title="👀 내 관심 기업" companies={MOCK_WATCHLIST} />
-          <button className="text-[13px] font-bold text-text-muted hover:text-text-primary">관심 기업 관리 →</button>
+          <Link
+          href="/mypage?tab=watchlist"
+          className="block text-center text-[13px] font-bold text-text-muted hover:text-text-primary">
+          관심 기업 관리 →
+        </Link>
         </div>
       </div>
     </main>

--- a/briefin/src/app/(CommonLayout)/home/page.tsx
+++ b/briefin/src/app/(CommonLayout)/home/page.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import HomeBanner from '@/components/home/HomeBanner';
 import AlertBanner from '@/components/common/AlertBanner';
 import NewsCard from '@/components/news/NewsCard';
@@ -49,7 +50,11 @@ export default function HomePage() {
               buttonLabel="🏢 관련 기업 추가하기"
             />
             <PopularCompanyList title="👀 내 관심 기업" companies={MOCK_WATCHLIST} />
-            <button className="text-[13px] font-bold text-text-muted hover:text-text-primary">관심 기업 관리 →</button>
+            <Link
+              href="/mypage?tab=watchlist"
+              className="block text-center text-[13px] font-bold text-text-muted hover:text-text-primary">
+              관심 기업 관리 →
+            </Link>
           </div>
         </div>
       </section>

--- a/briefin/src/app/(CommonLayout)/mypage/page.tsx
+++ b/briefin/src/app/(CommonLayout)/mypage/page.tsx
@@ -1,15 +1,31 @@
 'use client';
 
-import { useState } from 'react';
-import MyPageHeader from '@/components/mypage/mypageheader';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import Tabs from '@/components/common/Tabs';
+import MyPageHeader from '@/components/mypage/mypageheader';
 
 type MyPageTab = '관심 기업' | '스크랩 뉴스' | '최근 본 뉴스' | '계정 관리';
 
 const MY_PAGE_TABS: MyPageTab[] = ['관심 기업', '스크랩 뉴스', '최근 본 뉴스', '계정 관리'];
 
+const TAB_FROM_QUERY: Record<string, MyPageTab> = {
+  watchlist: '관심 기업',
+  scrap: '스크랩 뉴스',
+  recent: '최근 본 뉴스',
+  account: '계정 관리',
+};
+
 export default function MyPage() {
+  const searchParams = useSearchParams();
   const [activeTab, setActiveTab] = useState<MyPageTab>('스크랩 뉴스');
+
+  useEffect(() => {
+    const tab = searchParams.get('tab');
+    if (tab && TAB_FROM_QUERY[tab]) {
+      setActiveTab(TAB_FROM_QUERY[tab]);
+    }
+  }, [searchParams]);
 
   const handleLogout = () => {
     console.log('로그아웃');


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
14
## 📝 변경사항

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 우측 관심기업 설정 누르면 마이페이지의 관심기업으로 리다이렉트

### 🔍 주안점 & 리뷰 포인트

<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->
<!--
  - 예: 멀티 모듈 구조에서 의존성 주입 방식이 적절한지 봐주세요.
  - 예: Next.js App Router의 `params` 언래핑(unwrap) 처리가 올바른지 확인 부탁드립니다.
-->
리다이렉트 되는지 봐주세요

### 🖼️ 스크린샷 / 테스트 결과

<!--
  (Optional)
  작업 결과 만들거나 변경된 화면 스크린샷
  테스트 수행 결과 스크린샷
-->

---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] UI 마지막 체크


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 마이페이지 내 탭을 URL 쿼리 파라미터를 통해 직접 선택할 수 있도록 개선
  * 관심 기업 관리 페이지로의 네비게이션 개선으로 더 빠른 접근 가능

* **개선 사항**
  * 피드 및 홈 페이지에서 클라이언트 사이드 라우팅 적용으로 페이지 로딩 성능 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->