### PR TITLE
온보딩 뷰 수정

### DIFF
--- a/briefin/src/app/globals.css
+++ b/briefin/src/app/globals.css
@@ -13,7 +13,6 @@
   body {
     width: 100%;
     height: 100dvh;
-    min-height: 100dvh;
     margin: 0 auto;
     background-color: #f5f6f8;
     -ms-overflow-style: none;

--- a/briefin/src/app/onboarding/page.tsx
+++ b/briefin/src/app/onboarding/page.tsx
@@ -9,6 +9,8 @@ import {
 } from '@/mocks/mock-companies';
 import type { Company } from '@/types/company';
 
+const NEXT_PAGE = '/feed';
+
 function loadSelectedIds(): string[] {
   if (typeof window === 'undefined') return [];
   try {
@@ -24,7 +26,11 @@ function loadSelectedIds(): string[] {
 function saveSelectedIds(ids: string[]) {
   if (typeof window === 'undefined') return;
   try {
-    localStorage.setItem(STORAGE_KEY_SELECTED_COMPANIES, JSON.stringify(ids));
+    if (ids.length > 0) {
+      localStorage.setItem(STORAGE_KEY_SELECTED_COMPANIES, JSON.stringify(ids));
+    } else {
+      localStorage.removeItem(STORAGE_KEY_SELECTED_COMPANIES);
+    }
   } catch {
     // ignore
   }
@@ -33,7 +39,6 @@ function saveSelectedIds(ids: string[]) {
 export default function OnboardingPage() {
   const router = useRouter();
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [touched, setTouched] = useState(false);
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -41,13 +46,7 @@ export default function OnboardingPage() {
     setMounted(true);
   }, []);
 
-  useEffect(() => {
-    if (!mounted) return;
-    saveSelectedIds(selectedIds);
-  }, [selectedIds, mounted]);
-
   const toggle = (company: Company) => {
-    setTouched(true);
     setSelectedIds((prev) =>
       prev.includes(company.id)
         ? prev.filter((id) => id !== company.id)
@@ -55,31 +54,31 @@ export default function OnboardingPage() {
     );
   };
 
-  const isValid = selectedIds.length >= 1;
-  const showError = !isValid;
-
-  const handleSubmit = () => {
-    if (!isValid) {
-      setTouched(true);
-      return;
+  const goNext = () => {
+    if (mounted && selectedIds.length > 0) {
+      saveSelectedIds(selectedIds);
     }
-    router.push('/feed');
+    router.push(NEXT_PAGE);
+  };
+
+  const handleLater = () => {
+    router.push(NEXT_PAGE);
   };
 
   return (
-    <main className="min-h-screen bg-surface-bg px-16pxr pb-32pxr pt-40pxr sm:px-24pxr sm:pb-40pxr sm:pt-56pxr md:pt-64pxr lg:px-32pxr lg:pt-71pxr">
-      <div className="mx-auto w-full max-w-[1220px]">
+    <main className="h-screen bg-surface-bg px-16pxr pb-32pxr  sm:px-24pxr sm:pb-40pxr sm:pt-44pxr md:pt-52pxr">
+      <div className="mx-auto w-full max-w-[680px]">
         <div className="text-center">
           <p className="text-[40px] leading-none text-text-primary sm:text-[48px]">🏢</p>
-          <h1 className="mt-16pxr text-[22px] font-black tracking-[-0.5px] text-text-primary sm:mt-23pxr sm:text-[28px]">
+          <h1 className="mt-14pxr text-[22px] font-black tracking-[-0.5px] text-text-primary sm:mt-18pxr sm:text-[26px]">
             관심 기업을 선택해 주세요
           </h1>
-          <p className="mt-6pxr text-[14px] font-normal leading-relaxed text-text-muted sm:mt-4pxr sm:text-[15px] sm:leading-[21px]">
-            최소 1개 이상 선택하면 맞춤 피드를 시작할 수 있어요
+          <p className="mt-6pxr text-[14px] font-normal leading-relaxed text-text-muted sm:text-[15px]">
+            선택한 기업의 뉴스·공시를 맞춤으로 보여드려요 (선택 사항)
           </p>
         </div>
 
-        <div className="mt-20pxr grid grid-cols-2 gap-8pxr sm:mt-24pxr sm:gap-12pxr md:gap-16pxr">
+        <div className="mt-20pxr grid grid-cols-2 gap-10pxr sm:mt-24pxr sm:grid-cols-3 sm:gap-12pxr">
           {MOCK_ONBOARDING_COMPANIES.map((company) => (
             <CompanyCard
               key={company.id}
@@ -90,25 +89,22 @@ export default function OnboardingPage() {
           ))}
         </div>
 
-        {showError && (
-          <div
-            role="alert"
-            className="mt-20pxr flex min-h-[45px] items-center justify-center rounded-button border-2 border-dashed border-primary/60 bg-[#fff5f5] px-12pxr py-10pxr sm:mt-24pxr sm:h-[45px] sm:py-0"
+        <div className="mt-24pxr flex flex-col gap-10pxr sm:mt-28pxr sm:gap-12pxr">
+          <button
+            type="button"
+            onClick={goNext}
+            className="flex h-48pxr w-full items-center justify-center rounded-button bg-primary text-[14px] font-bold text-white shadow-sm transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary sm:h-[50px] sm:text-[15px]"
           >
-            <p className="text-center text-[12px] font-bold text-semantic-red sm:text-[13px]">
-              최소 1개 이상의 기업을 선택해 주세요.
-            </p>
-          </div>
-        )}
-
-        <button
-          type="button"
-          onClick={handleSubmit}
-          disabled={!isValid}
-          className="mt-20pxr flex h-48pxr w-full items-center justify-center rounded-button bg-primary text-[14px] font-bold leading-tight text-white shadow-sm transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none sm:mt-24pxr sm:h-[52px] sm:text-[15px]"
-        >
-          피드 시작하기 →
-        </button>
+            시작하기
+          </button>
+          <button
+            type="button"
+            onClick={handleLater}
+            className="text-[14px] font-bold text-text-muted transition-colors hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-surface-border sm:text-[15px]"
+          >
+            나중에 하기
+          </button>
+        </div>
       </div>
     </main>
   );

--- a/briefin/src/components/login/LoginSection.tsx
+++ b/briefin/src/components/login/LoginSection.tsx
@@ -9,7 +9,7 @@ export default function LoginSection() {
   const [password, setPassword] = useState('');
 
   return (
-    <section className="relative flex min-h-dvh w-full items-center justify-center overflow-hidden bg-primary-dark px-16pxr py-24pxr sm:px-24pxr sm:py-40pxr">
+    <section className="relative flex h-dvh w-full items-center justify-center overflow-hidden bg-primary-dark px-16pxr py-24pxr sm:px-24pxr sm:py-40pxr">
       {/* 배경 장식 */}
       <div className="size-r600pxr pointer-events-none absolute -left-200pxr -top-250pxr rounded-full bg-[radial-gradient(circle,rgba(44,74,143,0.45)_0%,transparent_70%)]" />
       <div className="pointer-events-none absolute -bottom-120pxr -right-80pxr size-350pxr rounded-full bg-[radial-gradient(circle,rgba(26,50,112,0.55)_0%,transparent_70%)]" />

--- a/briefin/src/components/onboarding/company-card.tsx
+++ b/briefin/src/components/onboarding/company-card.tsx
@@ -15,14 +15,14 @@ export default function CompanyCard({ company, selected, onToggle }: CompanyCard
     <button
       type="button"
       onClick={onToggle}
-      className={`flex min-h-[72px] w-full cursor-pointer items-center rounded-[12px] border px-14pxr py-12pxr text-left transition-colors sm:min-h-0 sm:h-[82px] sm:rounded-[14px] sm:px-18pxr sm:py-0 ${
+      className={`flex w-full cursor-pointer items-center rounded-xl border px-14pxr py-12pxr text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary sm:min-h-0 sm:h-80pxr sm:px-16pxr sm:py-0 ${
         selected
-          ? 'border-primary bg-primary-light ring-2 ring-primary'
-          : 'border-primary/60 border-dashed bg-surface-muted hover:border-primary hover:bg-surface-white'
+          ? 'border-primary bg-primary-light shadow-sm ring-2 ring-primary'
+          : 'border-surface-border bg-surface-white shadow-sm hover:border-primary/50 hover:bg-surface-bg'
       }`}
     >
       <div
-        className={`flex size-[40px] shrink-0 items-center justify-center rounded-[10px] text-[18px] sm:size-[44px] sm:rounded-[12px] sm:text-[20px] ${logoBg}`}
+        className={`flex size-40pxr shrink-0 items-center justify-center rounded-[10px] text-[18px] sm:size-[42px] sm:rounded-xl sm:text-[20px] ${logoBg}`}
       >
         {logo}
       </div>
@@ -34,7 +34,7 @@ export default function CompanyCard({ company, selected, onToggle }: CompanyCard
         >
           {name}
         </p>
-        <p className="mt-1pxr truncate text-[11px] font-normal leading-[15px] text-text-muted sm:mt-0 sm:text-[12px] sm:leading-[17px]">
+        <p className="mt-1pxr truncate text-11pxr font-normal leading-15pxr text-text-muted sm:mt-0 sm:text-12pxr sm:leading-[17px]">
           {industry}
         </p>
       </div>

--- a/briefin/src/mocks/mock-companies.ts
+++ b/briefin/src/mocks/mock-companies.ts
@@ -1,13 +1,13 @@
 import type { Company } from '@/types/company';
 
-/** 온보딩 관심 기업 선택용 더미 데이터 (9개). API 연동 시 fetch로 교체 */
+/** 온보딩 관심 기업 선택용 더미 데이터 (9개, 3x3 그리드). API 연동 시 fetch로 교체 */
 export const MOCK_ONBOARDING_COMPANIES: Company[] = [
-  { id: '1', name: '삼성전자', logo: '📱', industry: '반도체 · 전자', logoBg: 'bg-[#eff6ff]' },
-  { id: '2', name: '현대자동차', logo: '🚗', industry: '자동차', logoBg: 'bg-[#fff7ed]' },
-  { id: '3', name: 'SK하이닉스', logo: '💾', industry: '반도체', logoBg: 'bg-[#f0fdf4]' },
+  { id: '1', name: '삼성전자', logo: '📱', industry: '반도체·전자', logoBg: 'bg-[#eff6ff]' },
+  { id: '2', name: 'SK하이닉스', logo: '💾', industry: '반도체', logoBg: 'bg-[#f0fdf4]' },
+  { id: '3', name: '현대자동차', logo: '🚗', industry: '자동차', logoBg: 'bg-[#fff7ed]' },
   { id: '4', name: '카카오뱅크', logo: '🏦', industry: '뱅크', logoBg: 'bg-[#fdf4ff]' },
   { id: '5', name: 'LG에너지솔루션', logo: '🔋', industry: '배터리', logoBg: 'bg-[#fff7ed]' },
-  { id: '6', name: '네이버', logo: '🟢', industry: 'IT · 플랫폼', logoBg: 'bg-[#ecfdf5]' },
+  { id: '6', name: '네이버', logo: '🟢', industry: 'IT·플랫폼', logoBg: 'bg-[#ecfdf5]' },
   { id: '7', name: '카카오', logo: '💛', industry: '플랫폼', logoBg: 'bg-[#fefce8]' },
   { id: '8', name: '두산에너빌리티', logo: '⚡', industry: '에너지', logoBg: 'bg-[#eff6ff]' },
   { id: '9', name: '셀트리온', logo: '🧬', industry: '바이오', logoBg: 'bg-[#f0fdf4]' },


### PR DESCRIPTION
## #️⃣ Issue Number

#이슈번호

## 📝 변경사항

관심 기업 선택 온보딩 페이지를 선택 사항으로 완화하고, 진입 장벽을 낮추기 위해 리팩토링했습니다. 최소 1개 선택 필수·에러 메시지를 제거하고, "나중에 하기"로 선택 없이도 서비스 진입이 가능하도록 했으며, 그리드·컨테이너·버튼 구성을 정리했습니다.

### 🎯 핵심 변경 사항 (Key Changes)

- [x] 기업 선택 영역을 3×3 그리드로 변경 (데스크 3열, 태블릿 3열, 모바일 2열)
- [x] 메인 CTA 문구 "피드 시작하기" → "시작하기", 항상 활성화
- [x] 최소 1개 선택 validation 및 에러 메시지 영역 제거
- [x] "나중에 하기" 보조 버튼 추가 (선택 없이 다음 페이지 이동)
- [x] 선택된 기업이 있을 때만 localStorage 저장, 없을 때는 저장/제거 처리
- [x] 컨테이너 max-width 축소(680px), 버튼 영역 정리 및 focus 스타일 적용

### 🔍 주안점 & 리뷰 포인트

- "시작하기" 클릭 시에만 localStorage 저장/제거하는 흐름이 의도대로 동작하는지 확인 부탁드립니다.
- `/feed` 이외 다음 페이지로 변경 예정이 있다면 `NEXT_PAGE` 상수만 수정하면 됨을 참고 부탁드립니다.

### 🖼️ 스크린샷 / 테스트 결과

- `/onboarding` 3×3 그리드, 시작하기 / 나중에 하기 버튼 동작
- 선택 0개 → 시작하기 / 나중에 하기 모두 `/feed` 이동
- 선택 1개 이상 → 시작하기 시 localStorage 저장 후 `/feed` 이동

---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [x] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] 온보딩 완료 여부에 따른 라우팅 가드 검토 (선택)
- [ ] 관심 기업 목록 API 연동 시 `mocks` 교체

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **신기능**
  * 온보딩 중 회사 선택을 선택 사항으로 변경
  * "나중에 하기" 버튼으로 온보딩 프로세스 건너뛰기 가능

* **개선 사항**
  * 회사 카드의 UI 및 반응형 디자인 최적화
  * 온보딩 화면의 레이아웃 및 안내 텍스트 개선
  * 회사 목록 정보 정규화 및 순서 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->