### PR TITLE
탈퇴, 로그인 뷰 구현

### DIFF
--- a/briefin/src/app/(CommonLayout)/mypage/page.tsx
+++ b/briefin/src/app/(CommonLayout)/mypage/page.tsx
@@ -3,6 +3,7 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import Tabs from '@/components/common/Tabs';
 import MyPageHeader from '@/components/mypage/mypageheader';
+import AccountSection from '@/components/mypage/AccountSection';
 import { MyPageTab } from '@/types/mypage';
 import { TAB_FROM_QUERY, TAB_TO_QUERY } from '@/constants/mypage';
 import { MY_PAGE_TABS } from '@/constants/mypage';
@@ -30,7 +31,7 @@ export default function MyPage() {
         {activeTab === '관심 기업' && <div>{/* 관심 기업 컨텐츠 */}</div>}
         {activeTab === '스크랩 뉴스' && <div>{/* 스크랩 뉴스 컨텐츠 */}</div>}
         {activeTab === '최근 본 뉴스' && <div>{/* 최근 본 뉴스 컨텐츠 */}</div>}
-        {activeTab === '계정 관리' && <div>{/* 계정 관리 컨텐츠 */}</div>}
+        {activeTab === '계정 관리' && <AccountSection />}
       </div>
     </div>
   );

--- a/briefin/src/app/login-required/page.tsx
+++ b/briefin/src/app/login-required/page.tsx
@@ -1,0 +1,9 @@
+import LoginRequiredView from '@/components/auth/LoginRequiredView';
+
+export default function LoginRequiredPage() {
+  return (
+    <main className="min-h-screen bg-surface-bg">
+      <LoginRequiredView />
+    </main>
+  );
+}

--- a/briefin/src/components/auth/LoginRequiredView.tsx
+++ b/briefin/src/components/auth/LoginRequiredView.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+interface LoginRequiredViewProps {
+  /** 모달로 쓸 때 닫기 콜백. 없으면 페이지에서 사용, "다음에 할게요"는 router.back() */
+  onClose?: () => void;
+}
+
+export default function LoginRequiredView({ onClose }: LoginRequiredViewProps) {
+  const router = useRouter();
+
+  const handleLater = () => {
+    if (onClose) {
+      onClose();
+    } else {
+      router.push('/');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-surface-bg p-24pxr sm:p-32pxr">
+      <div
+        className="absolute inset-24pxr rounded-hero bg-black/5 sm:inset-32pxr"
+        aria-hidden
+      />
+      <div className="relative z-10 w-full max-w-440pxr rounded-modal bg-surface-white px-40pxr py-32pxr shadow-modal">
+        <p className="text-center text-[48px] leading-none" aria-hidden>
+          🔒
+        </p>
+        <h2 className="mt-16pxr text-center text-[22px] font-black tracking-[-0.5px] text-text-primary">
+          로그인이 필요해요
+        </h2>
+        <p className="mt-12pxr text-center text-[14px] font-normal leading-[22.4px] text-text-secondary">
+          로그인하면 관심 기업 등록, 스크랩, 맞춤 피드를 이용할 수{' '}
+          <span className="whitespace-nowrap">있어요.</span>
+        </p>
+
+        <div className="mt-24pxr flex flex-col gap-12pxr">
+          <Link
+            href="/login"
+            className="flex h-49pxr items-center justify-center rounded-button bg-primary text-[15px] font-bold text-white transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          >
+            로그인하기
+          </Link>
+          <Link
+            href="/signup"
+            className="flex h-51pxr items-center justify-center rounded-button border-2 border-primary bg-surface-white text-[15px] font-bold text-primary transition-colors hover:bg-primary-light focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          >
+            회원가입하기
+          </Link>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleLater}
+          className="mt-20pxr w-full text-center text-[14px] font-normal text-text-muted transition-colors hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-surface-border"
+        >
+          다음에 할게요
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/briefin/src/components/auth/WithdrawConfirmModal.tsx
+++ b/briefin/src/components/auth/WithdrawConfirmModal.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+interface WithdrawConfirmModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm?: () => void;
+}
+
+export default function WithdrawConfirmModal({
+  open,
+  onClose,
+  onConfirm,
+}: WithdrawConfirmModalProps) {
+  if (!open) return null;
+
+  const handleConfirm = () => {
+    onConfirm?.();
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-surface-bg p-24pxr sm:p-32pxr"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="withdraw-modal-title"
+    >
+      <div
+        className="absolute inset-24pxr rounded-hero bg-black/5 sm:inset-32pxr"
+        aria-hidden
+      />
+      <div className="relative z-10 w-full max-w-440pxr rounded-modal bg-surface-white px-40pxr py-32pxr shadow-modal">
+        <p className="text-center text-[48px] leading-none" aria-hidden>
+          ⚠️
+        </p>
+        <h2
+          id="withdraw-modal-title"
+          className="mt-16pxr text-center text-[22px] font-black tracking-[-0.5px] text-text-primary"
+        >
+          정말 탈퇴하시겠어요?
+        </h2>
+        <p className="mt-12pxr text-center text-[14px] font-normal leading-[22.4px] text-text-secondary">
+          탈퇴하면 모든 데이터(관심 기업, 스크랩, 히스토리)가
+          <br />
+          영구적으로 삭제되며 <span className="whitespace-nowrap">복구할 수 없습니다.</span>
+        </p>
+
+        <button
+          type="button"
+          onClick={handleConfirm}
+          className="mt-24pxr flex h-49pxr w-full items-center justify-center rounded-button bg-semantic-red text-[15px] font-bold text-white shadow-modal transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-semantic-red"
+        >
+          탈퇴하기
+        </button>
+
+        <button
+          type="button"
+          onClick={onClose}
+          className="mt-16pxr w-full text-center text-[14px] font-normal text-text-muted transition-colors hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-surface-border"
+        >
+          취소
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/briefin/src/components/mypage/AccountSection.tsx
+++ b/briefin/src/components/mypage/AccountSection.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import WithdrawConfirmModal from '@/components/auth/WithdrawConfirmModal';
+import { STORAGE_KEY_SELECTED_COMPANIES } from '@/mocks/mock-companies';
+
+export default function AccountSection() {
+  const router = useRouter();
+  const [showWithdrawModal, setShowWithdrawModal] = useState(false);
+
+  const handleWithdrawConfirm = () => {
+    try {
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem(STORAGE_KEY_SELECTED_COMPANIES);
+      }
+    } catch {
+      // ignore
+    }
+    router.push('/');
+  };
+
+  return (
+    <>
+      <div className="rounded-card border border-surface-border bg-surface-white p-24pxr">
+        <h3 className="text-[15px] font-bold text-text-primary">계정</h3>
+        <button
+          type="button"
+          onClick={() => setShowWithdrawModal(true)}
+          className="mt-16pxr text-[14px] font-bold text-text-muted underline transition-colors hover:text-semantic-red"
+        >
+          회원 탈퇴
+        </button>
+      </div>
+
+      <WithdrawConfirmModal
+        open={showWithdrawModal}
+        onClose={() => setShowWithdrawModal(false)}
+        onConfirm={handleWithdrawConfirm}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
#️⃣ Issue Number
#52 

📝 변경사항
회원 탈퇴 확인 모달 및 계정 관리 섹션 추가
마이페이지 "계정 관리" 탭에서 회원 탈퇴 플로우를 제공하기 위해 탈퇴 확인 모달과 계정 관리 UI를 구현했습니다.
탈퇴 확인 시 로컬 저장 데이터(관심 기업 등)를 정리하고 홈으로 이동하도록 했으며, 추후 탈퇴 API 연동 시 onConfirm 콜백만 확장하면 됩니다.
🎯 핵심 변경 사항 (Key Changes)

WithdrawConfirmModal
컴포넌트 추가 (정말 탈퇴하시겠어요? 모달, 탈퇴하기/취소 액션)

AccountSection
컴포넌트 추가 (계정 관리 탭 콘텐츠, 회원 탈퇴 버튼 → 모달 오픈)

마이페이지에서 "계정 관리" 탭 선택 시
AccountSection
렌더링하도록 연동
🔍 주안점 & 리뷰 포인트
탈퇴 확인 모달은 LoginRequiredView와 동일한 오버레이/카드 레이아웃·토큰(pxr, semantic-red)을 사용해 일관성을 맞췄습니다.
설명 문장 끝 "복구할 수 없습니다."는 whitespace-nowrap으로 줄바꿈 시 단어가 쪼개지지 않도록 처리했습니다.
접근성: role="dialog", aria-modal, aria-labelledby 및 포커스 스타일 적용 여부 확인 부탁드립니다.
🖼️ 스크린샷 / 테스트 결과
마이페이지 → 계정 관리 탭 → "회원 탈퇴" 클릭 시 탈퇴 확인 모달 노출
"탈퇴하기" 클릭 시 localStorage selectedCompanies 제거 후 / 이동
"취소" 클릭 시 모달만 닫힘
🛠️ PR 유형

✨ 새로운 기능 추가

🐛 버그 수정

💄 UI/UX 디자인 변경

♻️ 리팩토링

📝 문서 수정 (Docs)

✅ 테스트 추가/수정

🔧 빌드/패키지 매니저/CI 설정 수정
✅ 다음 할일

회원 탈퇴 API 연동 시
AccountSection
의
handleWithdrawConfirm
에서 API 호출 추가

(선택) 탈퇴 성공/실패 토스트 또는 메시지 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증이 필요한 경우 로그인 또는 회원가입을 유도하는 모달 페이지 추가
  * 계정 관리 섹션에 회원 탈퇴 기능 구현 (탈퇴 확인 모달 포함)
  * 내 페이지의 계정 관리 탭을 기존 플레이스홀더에서 실제 기능으로 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->