### PR TITLE
공시상세페이지 수정

### DIFF
--- a/briefin/src/components/disclosure/DisclosureDetails.tsx
+++ b/briefin/src/components/disclosure/DisclosureDetails.tsx
@@ -2,22 +2,32 @@ import { DisclosureDetailsProps } from '@/types/disclosure';
 import { ROWS } from '@/constants/disclosure';
 
 export default function DisclosureDetails({ details }: DisclosureDetailsProps) {
+  // `1,240,000,000,000원`처럼 숫자+단위가 붙어있는 문자열은
+  // 모바일에서 줄바꿈 기회가 부족해 overflow가 날 수 있어 단위(`원`)만 붙여주고,
+  // 실제 줄바꿈은 CSS의 overflow-wrap로 처리합니다.
+  function normalizeAmountForWrap(value: string) {
+    return value.replace(/(\d[\d,]*)원/g, '$1\u00A0원');
+  }
+
   return (
     <div className="rounded-summary bg-surface-bg p-20pxr">
       <dl className="space-y-0">
         {ROWS.map(({ key, label, highlight }) => {
           const value = details[key as keyof typeof details];
           if (value == null) return null;
+
+          const displayValue = key === 'amount' ? normalizeAmountForWrap(value) : value;
+
           return (
             <div
               key={key}
-              className="flex border-b border-surface-border py-14pxr first:pt-0 last:border-b-0 last:pb-0">
-              <dt className="w-140pxr shrink-0 text-[14px] font-bold leading-7 text-text-muted">{label}</dt>
+              className="min-w-0 flex flex-col border-b border-surface-border py-14pxr first:pt-0 last:border-b-0 last:pb-0 sm:flex-row sm:items-start sm:gap-0">
+              <dt className="w-full shrink-0 text-[14px] font-bold leading-7 text-text-muted sm:w-140pxr">{label}</dt>
               <dd
-                className={`min-w-0 flex-1 text-[14px] leading-7 ${
+                className={`min-w-0 flex-1 text-[14px] leading-7 whitespace-normal break-words [overflow-wrap:anywhere] ${
                   highlight ? 'font-bold text-primary' : 'font-normal text-text-secondary'
                 }`}>
-                {value}
+                {displayValue}
               </dd>
             </div>
           );


### PR DESCRIPTION
#️⃣ Issue Number
#미정 (모바일 공시 상세 숫자 overflow/레이아웃 깨짐)
📝 변경사항
모바일에서 계약 금액처럼 긴 숫자(예: 1,240,000,000,000원)가 공시 상세의 label/value(dt/dd) 영역을 벗어나 잘리는 문제를 수정했습니다.
기존에는 dt(dd)가 모바일에서도 가로(flex row) 형태로 유지되어 줄바꿈 기회가 부족했기 때문에, label/value를 모바일에서 세로 정렬로 바꾸고 dd 텍스트에 줄바꿈/오버플로우 방지 스타일을 추가했습니다. 또한 원 단위가 숫자와 분리되지 않도록 amount 문자열의 단위 결합을 보정했습니다.

🎯 핵심 변경 사항 (Key Changes)

DisclosureDetails
에서 모바일 레이아웃을
label/value
세로 정렬로 변경 (
flex-col
+
sm:flex-row
)

dd
에
whitespace-normal
,
break-words
,
overflow-wrap:anywhere
적용하여 긴 숫자/문자열이 영역을 벗어나지 않도록 방지

amount
값의
숫자원
패턴을
숫자 + 논브레이킹 공백 + 원
으로 정규화하여 단위가 자연스럽게 함께 줄바꿈되도록 개선
🔍 주안점 & 리뷰 포인트

모바일에서
dt
가
w-full
로 늘어나 줄바꿈/레이아웃이 의도대로 동작하는지 확인 부탁드립니다.

dd
의
[overflow-wrap:anywhere]
및
break-words
조합으로 정말 “컨테이너 밖 튐”이 사라지는지 확인 부탁드립니다.

amount
정규화(
/(\d[\d,]*)원/g
)가 현재 데이터 포맷에서만 적용되며 부작용이 없는지(다른 단위/문구 포함 여부) 검토 부탁드립니다.
🖼️ 스크린샷 / 테스트 결과

로컬에서 모바일 폭(예: 360~390px)으로
공시 상세
페이지 렌더링 확인 필요

계약 금액
행이 줄바꿈되어도 가독성이 유지되는지 확인 필요
🛠️ PR 유형

🐛 버그 수정

💄 UI/UX 디자인 변경

♻️ 리팩토링

📝 문서 수정 (Docs)

✅ 테스트 추가/수정

🔧 빌드/패키지 매니저/CI 설정 수정

✨ 새로운 기능 추가
✅ 다음 할일

모바일(320~390px) + 태블릿(768px)에서
공시 상세
스크롤/줄바꿈 동작 재확인

amount
외에 다른 숫자+단위 조합(예:
500원
,
억 원
)이 있다면 동일 규칙 적용 범위 검토

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 통화 단위가 포함된 금액이 모바일 화면에서 올바르게 줄바꿈되도록 개선
  * 긴 내용이 포함된 상세 정보가 더 이상 텍스트 오버플로우 없이 표시됨

* **개선 사항**
  * 소형 화면과 대형 화면에 맞춘 반응형 레이아웃 최적화
  * 금액 필드의 가독성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->