### PR TITLE
fix: api 파일 내 type 분리

### DIFF
--- a/briefin/src/api/authApi.ts
+++ b/briefin/src/api/authApi.ts
@@ -1,19 +1,7 @@
 import { apiClient, type ApiResponse } from './client';
+import type { LoginRequest, SignupRequest, LoginResponse } from '@/types/auth';
 
-export interface LoginRequest {
-  email: string;
-  password: string;
-}
-
-export interface SignupRequest {
-  email: string;
-  password: string;
-  passwordConfirm: string;
-}
-
-export interface LoginResponse {
-  accessToken: string;
-}
+export type { LoginRequest, SignupRequest, LoginResponse };
 
 export const login = (body: LoginRequest) =>
   apiClient.post<ApiResponse<LoginResponse>>('/api/auth/login', body).then((res) => res.result);

--- a/briefin/src/api/companyApi.ts
+++ b/briefin/src/api/companyApi.ts
@@ -1,17 +1,7 @@
 import { apiClient, type ApiResponse } from './client';
+import type { CompanyDetail } from '@/types/company';
 
-export interface CompanyDetail {
-  id: number;
-  name: string;
-  ticker: string;
-  sector: string;
-  logoUrl: string;
-  currentPrice: number;
-  changeRate: number;
-  marketCap: number;
-  isOverseas: boolean;
-  relatedCompanies: { id: number; name: string; ticker: string }[];
-}
+export type { CompanyDetail };
 
 // 기업 상세 조회
 export const fetchCompanyDetail = (id: number) =>

--- a/briefin/src/api/newsApi.ts
+++ b/briefin/src/api/newsApi.ts
@@ -1,33 +1,7 @@
 import { apiClient, type ApiResponse } from './client';
+import type { NewsListItem, NewsDetailResponse, ScrapResponse, NewsItem } from '@/types/news';
 
-export interface NewsListItem {
-  newsId: string;
-  title: string;
-  summary: string;
-  category: string;
-  region: string;
-  press: string;
-  publishedAt: string;
-  relatedCompanies: string[];
-}
-
-export interface NewsDetailResponse {
-  newsId: string;
-  title: string;
-  content: string;
-  summary: string;
-  category: string;
-  press: string;
-  publishedAt: string;
-  relatedCompanies: string[];
-  relatedNews: string[];
-}
-
-export interface ScrapResponse {
-  newsId: number;
-  isScraped: boolean;
-  scrapedAt: string;
-}
+export type { NewsListItem, NewsDetailResponse, ScrapResponse };
 
 // 뉴스 목록 조회 (category 없으면 전체)
 export const fetchNewsList = (category?: string) => {
@@ -60,8 +34,6 @@ export const deleteScrapNews = (id: string | number) =>
   apiClient.delete<ApiResponse<null>>(`/api/news/${id}/scrap`);
 
 // 백엔드 NewsListItem → 프론트 NewsItem 변환
-import type { NewsItem } from '@/types/news';
-
 export function toNewsItem(item: NewsListItem): NewsItem {
   return {
     id: String(item.newsId),

--- a/briefin/src/api/userApi.ts
+++ b/briefin/src/api/userApi.ts
@@ -1,26 +1,7 @@
 import { apiClient, type ApiResponse } from './client';
+import type { UserInfo, ScrapedNews, WatchlistCompany } from '@/types/mypage';
 
-export interface UserInfo {
-  userId: string;
-  email: string;
-  createdAt: string;
-}
-
-export interface ScrapedNews {
-  newsId: number;
-  title: string;
-  summary: string;
-  source: string;
-  scrapedAt: string;
-}
-
-export interface WatchlistCompany {
-  companyId: number;
-  companyName: string;
-  ticker: string;
-  logoUrl: string;
-  addedAt: string;
-}
+export type { UserInfo, ScrapedNews, WatchlistCompany };
 
 // 내 정보 조회
 export const fetchMyInfo = () =>

--- a/briefin/src/types/auth.ts
+++ b/briefin/src/types/auth.ts
@@ -1,0 +1,15 @@
+// API 요청/응답 타입
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface SignupRequest {
+  email: string;
+  password: string;
+  passwordConfirm: string;
+}
+
+export interface LoginResponse {
+  accessToken: string;
+}

--- a/briefin/src/types/company.ts
+++ b/briefin/src/types/company.ts
@@ -1,3 +1,17 @@
+// API 응답 타입
+export interface CompanyDetail {
+  id: number;
+  name: string;
+  ticker: string;
+  sector: string;
+  logoUrl: string;
+  currentPrice: number;
+  changeRate: number;
+  marketCap: number;
+  isOverseas: boolean;
+  relatedCompanies: { id: number; name: string; ticker: string }[];
+}
+
 export type Company = {
   id: string;
   name: string;

--- a/briefin/src/types/mypage.ts
+++ b/briefin/src/types/mypage.ts
@@ -1,1 +1,24 @@
 export type MyPageTab = '관심 기업' | '스크랩 뉴스' | '최근 본 뉴스' | '계정 관리';
+
+// API 응답 타입
+export interface UserInfo {
+  userId: string;
+  email: string;
+  createdAt: string;
+}
+
+export interface ScrapedNews {
+  newsId: number;
+  title: string;
+  summary: string;
+  source: string;
+  scrapedAt: string;
+}
+
+export interface WatchlistCompany {
+  companyId: number;
+  companyName: string;
+  ticker: string;
+  logoUrl: string;
+  addedAt: string;
+}

--- a/briefin/src/types/news.ts
+++ b/briefin/src/types/news.ts
@@ -1,5 +1,35 @@
 import type { MockNewsDetailRaw } from '@/mocks/newsDetail';
 
+// API 응답 타입
+export interface NewsListItem {
+  newsId: string;
+  title: string;
+  summary: string;
+  category: string;
+  region: string;
+  press: string;
+  publishedAt: string;
+  relatedCompanies: string[];
+}
+
+export interface NewsDetailResponse {
+  newsId: string;
+  title: string;
+  content: string;
+  summary: string;
+  category: string;
+  press: string;
+  publishedAt: string;
+  relatedCompanies: string[];
+  relatedNews: string[];
+}
+
+export interface ScrapResponse {
+  newsId: number;
+  isScraped: boolean;
+  scrapedAt: string;
+}
+
 export interface NewsItem {
   id: string;
   source: string; // 언론사


### PR DESCRIPTION
## #️⃣ Issue Number

63

## 📝 변경사항

api 파일 내에 type 선언해둔 것들 type 폴더로 이동

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] auth, company, mypage, news, disclosure 타입 파일 수정린샷 / 테스트 결과


---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [x] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] api 연결 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * API 타입 정의를 중앙화된 타입 모듈로 통합하여 코드 구조를 개선했습니다. 인증, 회사, 뉴스, 마이페이지 관련 타입 정의가 재구성되었으며, 기능상 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->