### PR TITLE
feat: 홈 배너 슬라이더 및 페이드업 애니메이션 추가

### DIFF
--- a/briefin/src/components/home/HomeBanner.tsx
+++ b/briefin/src/components/home/HomeBanner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 
 const SLIDES = [
   {
@@ -37,29 +37,40 @@ const SLIDES = [
 
 const INTERVAL = 4000;
 
-const fadeUpStyle = (delay: number): React.CSSProperties => ({
+const fadeUpStyle = (delay: number): CSSProperties => ({
   animation: `bannerFadeUp 0.5s ease both`,
   animationDelay: `${delay}ms`,
 });
 
 export default function HomeBanner() {
   const [current, setCurrent] = useState(0);
+  const [paused, setPaused] = useState(false);
+  const [tick, setTick] = useState(0);
 
   useEffect(() => {
+    if (paused) return;
     const timer = setInterval(() => {
       setCurrent((prev) => (prev + 1) % SLIDES.length);
     }, INTERVAL);
     return () => clearInterval(timer);
-  }, []);
+  }, [paused, tick]);
 
-  const prev = () => setCurrent((c) => (c - 1 + SLIDES.length) % SLIDES.length);
-  const next = () => setCurrent((c) => (c + 1) % SLIDES.length);
+  const prev = () => {
+    setCurrent((c) => (c - 1 + SLIDES.length) % SLIDES.length);
+    setTick((t) => t + 1);
+  };
+  const next = () => {
+    setCurrent((c) => (c + 1) % SLIDES.length);
+    setTick((t) => t + 1);
+  };
 
   const slide = SLIDES[current];
 
   return (
     <section
       className="relative min-h-400pxr w-full overflow-hidden"
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
       style={{
         background: 'linear-gradient(106deg, #F5F0E8 0%, #E0D8C8 60%, #F5F0E8 100%)',
       }}>
@@ -71,14 +82,15 @@ export default function HomeBanner() {
       `}</style>
 
       <div className="mx-auto flex h-full min-h-400pxr w-full max-w-1600pxr flex-row items-center">
-        {/* 왼쪽 텍스트 블럭 — key 변경 시 리마운트로 애니메이션 재실행 */}
-        <div key={current} className="ml-8 flex shrink-0 flex-col gap-6 px-48pxr py-16">
+        {/* 왼쪽 텍스트 블럭 */}
+        <div className="ml-8 flex shrink-0 flex-col gap-6 px-48pxr py-16">
           <h1
+            key={`title-${current}`}
             className="fonts-display whitespace-pre-line text-[#1A1D1F]"
             style={fadeUpStyle(0)}>
             {slide.title}
           </h1>
-          <ul className="flex flex-col gap-2">
+          <ul key={`bullets-${current}`} className="flex flex-col gap-2">
             {slide.bullets.map((b, i) => (
               <li
                 key={b}
@@ -89,7 +101,7 @@ export default function HomeBanner() {
             ))}
           </ul>
 
-          <div className="flex items-center gap-6" style={fadeUpStyle(240)}>
+          <div className="flex items-center gap-6">
             <div className="flex items-center overflow-hidden rounded-full border border-[#C4B49A] bg-[#C4B49A]">
               <button
                 onClick={prev}
@@ -111,6 +123,7 @@ export default function HomeBanner() {
         {/* 오른쪽 이미지 */}
         {slide.imageSrc && (
           <div
+            key={`image-${current}`}
             className="relative ml-auto mr-48 flex items-end justify-end self-stretch"
             style={fadeUpStyle(100)}>
             <img


### PR DESCRIPTION
## #️⃣ Issue Number

74

## 📝 변경사항

페이지 별 기능을 소개하기 위해 배너를 5개 버전으로 나눴습니다. 

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 배너5개로 구성

### 🔍 주안점 & 리뷰 포인트

### 🖼️ 스크린샷 / 테스트 결과

<img width="723" height="443" alt="image" src="https://github.com/user-attachments/assets/d4ce3522-0c93-4914-a674-ebc085260823" />


---

## 🛠️ PR 유형

- [o] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] 배너에 들어갈 이미지 탐색


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 홈 배너가 클라이언트 측에서 슬라이드 기반으로 동작하도록 업데이트되었습니다.
  * 각 슬라이드에 고유한 이미지와 콘텐츠가 표시됩니다.
  * 마우스 오버 시 자동 진행이 일시정지됩니다.
  * 이전/다음 버튼으로 수동 제어 가능합니다.
  * 슬라이드 전환이 일정 간격으로 자동 진행됩니다.

* **스타일**
  * 제목, 항목, 이미지에 페이드 업 애니메이션이 적용되어 전환이 부드러워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->