### PR TITLE
fix: 기업이벤트 카테고리 필터 id 공백 제거로 DB 값과 일치

### DIFF
--- a/briefin/src/constants/tickerCategories.ts
+++ b/briefin/src/constants/tickerCategories.ts
@@ -1,7 +1,7 @@
 export const TICKER_CATEGORIES = [
   { id: 'all', label: '전체' },
   { id: '기업실적', label: '기업실적' },
-  { id: '기업 이벤트', label: '기업 이벤트' },
+  { id: '기업이벤트', label: '기업 이벤트' },
   { id: '산업섹터', label: '산업섹터' },
   { id: '금융시장', label: '금융시장' },
   { id: '거시경제', label: '거시경제' },


### PR DESCRIPTION
## #️⃣ Issue Number

77

## 📝 변경사항

뉴스 탭에서 기업 이벤트로 필터링 하던 것을 기업이벤트로 필터링하도록 변경

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] tickerCategories.ts의 기업 이벤트 필터 id 값을 "기업 이벤트" → "기업이벤트"로 수정
- [ ]  DB news_summaries.category 저장 값("기업이벤트")과 프론트 필터 id를 일치시켜 필터링 정상 동작

### 🖼️ 스크린샷 / 테스트 결과
<img width="710" height="637" alt="image" src="https://github.com/user-attachments/assets/44065541-29a3-4eee-9afa-59373a7ae0dd" />


---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] 뉴스 상세페이지 오류 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 기업 이벤트 카테고리 식별자 형식을 표준화했습니다. 사용자에게 표시되는 카테고리명은 변경되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->