### PR TITLE
회원탈퇴 api 연결

### DIFF
--- a/briefin/src/api/userApi.ts
+++ b/briefin/src/api/userApi.ts
@@ -7,6 +7,9 @@ export type { UserInfo, ScrapedNews, WatchlistCompany };
 export const fetchMyInfo = () =>
   apiClient.get<ApiResponse<UserInfo>>('/api/users/me').then((res) => res.result);
 
+// 회원 탈퇴
+export const deleteMyAccount = () => apiClient.delete<ApiResponse<unknown>>('/api/users/me');
+
 // 스크랩한 뉴스 목록
 export const fetchScrappedNews = (page = 1, size = 10) =>
   apiClient

--- a/briefin/src/components/auth/WithdrawConfirmModal.tsx
+++ b/briefin/src/components/auth/WithdrawConfirmModal.tsx
@@ -4,18 +4,21 @@ interface WithdrawConfirmModalProps {
   open: boolean;
   onClose: () => void;
   onConfirm?: () => void;
+  isDeleting?: boolean;
+  errorMessage?: string | null;
 }
 
 export default function WithdrawConfirmModal({
   open,
   onClose,
   onConfirm,
+  isDeleting = false,
+  errorMessage,
 }: WithdrawConfirmModalProps) {
   if (!open) return null;
 
   const handleConfirm = () => {
     onConfirm?.();
-    onClose();
   };
 
   return (
@@ -48,14 +51,20 @@ export default function WithdrawConfirmModal({
         <button
           type="button"
           onClick={handleConfirm}
+          disabled={isDeleting}
           className="mt-24pxr flex h-49pxr w-full items-center justify-center rounded-button bg-semantic-red text-[15px] font-bold text-white shadow-modal transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-semantic-red"
         >
-          탈퇴하기
+          {isDeleting ? '탈퇴 처리 중...' : '탈퇴하기'}
         </button>
+
+        {errorMessage && (
+          <p className="mt-12pxr text-center text-[13px] font-semibold text-semantic-red">{errorMessage}</p>
+        )}
 
         <button
           type="button"
           onClick={onClose}
+          disabled={isDeleting}
           className="mt-16pxr w-full text-center text-[14px] font-normal text-text-muted transition-colors hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-surface-border"
         >
           취소

--- a/briefin/src/components/mypage/AccountSection.tsx
+++ b/briefin/src/components/mypage/AccountSection.tsx
@@ -3,21 +3,34 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import WithdrawConfirmModal from '@/components/auth/WithdrawConfirmModal';
+import { deleteMyAccount } from '@/api/userApi';
 import { STORAGE_KEY_SELECTED_COMPANIES } from '@/mocks/mock-companies';
+import { authStore } from '@/store/authStore';
 
 export default function AccountSection() {
   const router = useRouter();
   const [showWithdrawModal, setShowWithdrawModal] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
-  const handleWithdrawConfirm = () => {
+  const handleWithdrawConfirm = async () => {
+    if (isDeleting) return;
+    setIsDeleting(true);
+    setDeleteError(null);
+
     try {
+      await deleteMyAccount();
       if (typeof window !== 'undefined') {
         localStorage.removeItem(STORAGE_KEY_SELECTED_COMPANIES);
       }
+      authStore.clear();
+      setShowWithdrawModal(false);
+      router.replace('/');
     } catch {
-      // ignore
+      setDeleteError('회원 탈퇴 처리에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setIsDeleting(false);
     }
-    router.push('/');
   };
 
   return (
@@ -26,7 +39,10 @@ export default function AccountSection() {
         <h3 className="text-[15px] font-bold text-text-primary">계정</h3>
         <button
           type="button"
-          onClick={() => setShowWithdrawModal(true)}
+          onClick={() => {
+            setDeleteError(null);
+            setShowWithdrawModal(true);
+          }}
           className="mt-16pxr text-[14px] font-bold text-text-muted underline transition-colors hover:text-semantic-red"
         >
           회원 탈퇴
@@ -35,8 +51,13 @@ export default function AccountSection() {
 
       <WithdrawConfirmModal
         open={showWithdrawModal}
-        onClose={() => setShowWithdrawModal(false)}
+        onClose={() => {
+          if (isDeleting) return;
+          setShowWithdrawModal(false);
+        }}
         onConfirm={handleWithdrawConfirm}
+        isDeleting={isDeleting}
+        errorMessage={deleteError}
       />
     </>
   );


### PR DESCRIPTION
#️⃣ Issue Number
#83

📝 변경사항
JWT 인증 흐름을 현재 구조(authStore + apiClient(fetch))에 맞춰 안정화하고, 마이페이지 회원탈퇴 기능을 실제 API와 연결했습니다.
비로그인 접근 제어(피드/릴스), 401 발생 시 refresh 재시도 후 실패 시 로그인 리다이렉트, 로그인 후 원래 경로 복귀를 적용해 인증 UX를 일관되게 맞췄습니다.
또한 계정 관리의 “회원 탈퇴” 모달에서 실제 DELETE /api/users/me 호출, 로딩/에러 처리, 중복 요청 방지를 추가해 실사용 가능한 흐름으로 보강했습니다.

🎯 핵심 변경 사항 (Key Changes)

보호 라우트 적용:
/feed
,
/reels
비로그인 접근 시
/login?redirect=...
이동

apiClient
401 처리 강화: refresh 시도 → 성공 시 1회 재요청 → 실패 시 토큰 제거 및 로그인 이동

로그인 성공 후
redirect
쿼리 경로로 복귀(없으면
/
)

회원탈퇴 API 연동:
DELETE /api/users/me
호출 + 성공 시
authStore.clear()
후 홈 이동

탈퇴 모달 UX 개선:
isDeleting
로딩 상태, 버튼 비활성화, 실패 메시지 표시
🔍 주안점 & 리뷰 포인트
refresh 재시도 로직이 동시 401 상황에서 의도대로 단일 refresh 흐름으로 수렴하는지 확인 부탁드립니다.
AuthSessionProvider 초기 refresh 완료 시점과 보호 레이아웃(feed/reels)의 렌더 대기 타이밍이 UX적으로 자연스러운지 봐주세요.
회원탈퇴 실패 시 모달 내 에러 메시지 처리/재시도 UX가 충분한지 확인 부탁드립니다.
🖼️ 스크린샷 / 테스트 결과

타입 검사 통과:
pnpm exec tsc --noEmit

비로그인 상태에서
/feed
,
/reels
접근 시 로그인 리다이렉트 캡처

로그인 후
redirect
경로 복귀 동작 캡처

회원탈퇴 성공/실패(에러 메시지) UI 캡처
🛠️ PR 유형

✨ 새로운 기능 추가

🐛 버그 수정

💄 UI/UX 디자인 변경

♻️ 리팩토링

📝 문서 수정 (Docs)

✅ 테스트 추가/수정

🔧 빌드/패키지 매니저/CI 설정 수정
✅ 다음 할일

마이페이지 헤더 이메일을 실제
fetchMyInfo
데이터로 연결

E2E(로그인/리다이렉트/회원탈퇴) 시나리오 테스트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 계정 삭제 기능이 추가되었습니다.
  * 회원 탈퇴 시 처리 중 상태를 명확하게 표시합니다.
  * 탈퇴 과정에서 발생하는 오류 메시지를 화면에 표시합니다.
  * 탈퇴 완료 후 자동으로 홈 화면으로 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->