### PR TITLE
fix: companies 페이지 JSON 파싱 오류 처리 추가

### DIFF
--- a/briefin/src/app/(CommonLayout)/companies/page.tsx
+++ b/briefin/src/app/(CommonLayout)/companies/page.tsx
@@ -71,12 +71,15 @@ export default function Page() {
     fetch(`${process.env.NEXT_PUBLIC_API_URL}${TABS[activeTab].endpoint}`)
       .then(res => res.text())
       .then(text => {
-        if (!text) return;
+        if (!text) {
+          setCompanies([]);
+          return;
+        }
         try {
           const data = JSON.parse(text);
           setCompanies(data.result ?? []);
         } catch {
-          // HTML 에러 페이지 등 JSON이 아닌 응답 무시
+          setCompanies([]);
         }
       })
       .catch(console.error)


### PR DESCRIPTION
## #️⃣ Issue Number

117

## 📝 변경사항

기업페이지 Json 파싱 수정

### 🎯 핵심 변경 사항 (Key Changes)

- [x] API 응답이 JSON이 아닌 경우(HTML 에러 페이지 등) try-catch로 파싱 오류 처리
- [x] 파싱 실패 시 빈 목록 유지, 콘솔 SyntaxError 제거

## ✅ 다음 할일

- [ ] 전체적인 UI QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 회사 목록 조회 시 빈 응답을 안전하게 처리하도록 개선
  * 비정형/비JSON 응답으로 인한 파싱 오류 발생 시 앱이 정상 동작하도록 강화
  * 파싱 성공 시에만 목록을 갱신하도록 변경하여 이전 상태가 의도치 않게 유지되는 문제 해결
  * 로딩 상태가 항상 올바르게 해제되도록 안정성 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->