### PR TITLE
feat: 마이페이지 로그인 이메일 정보 제공

### DIFF
--- a/briefin/src/components/mypage/AccountSection.tsx
+++ b/briefin/src/components/mypage/AccountSection.tsx
@@ -6,9 +6,11 @@ import WithdrawConfirmModal from '@/components/auth/WithdrawConfirmModal';
 import { deleteMyAccount } from '@/api/userApi';
 import { STORAGE_KEY_SELECTED_COMPANIES } from '@/mocks/mock-companies';
 import { authStore } from '@/store/authStore';
+import { useMyInfo } from '@/hooks/useUser';
 
 export default function AccountSection() {
   const router = useRouter();
+  const { data: userInfo } = useMyInfo();
   const [showWithdrawModal, setShowWithdrawModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -36,7 +38,7 @@ export default function AccountSection() {
   return (
     <>
       <div className="rounded-card border border-surface-border bg-surface-white p-24pxr">
-        <h3 className="text-[15px] font-bold text-text-primary">계정</h3>
+        <h3 className="text-[15px] font-bold text-text-primary">{userInfo?.email ?? '계정'}</h3>
         <button
           type="button"
           onClick={() => {


### PR DESCRIPTION
## #️⃣ Issue Number

122

## 📝 변경사항

마이페이지 계정 상태에서, "계정" 텍스트 대신 userInfo?.email을 표시하도록 변경

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] useMyInfo hook을 AccountSection.tsx에 추가

### 🖼️ 스크린샷 / 테스트 결과

<img width="893" height="337" alt="image" src="https://github.com/user-attachments/assets/ecf0c723-0f9e-4505-908d-ca08bdfa4212" />

---

## 🛠️ PR 유형

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선사항**
  * 계정 섹션의 헤더가 정적 텍스트에서 사용자의 이메일 주소를 동적으로 표시하도록 변경되었습니다. 이메일이 없을 경우 기본값으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->