### PR TITLE
refresh 중복 호출 및 타이밍 이슈 수정

### DIFF
--- a/briefin/src/api/client.ts
+++ b/briefin/src/api/client.ts
@@ -1,7 +1,8 @@
 import { authStore } from '@/store/authStore';
+import { authDebug } from '@/lib/authDebug';
+import { refreshAccessTokenSingleFlight } from '@/lib/refreshSession';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080';
-let refreshPromise: Promise<string | null> | null = null;
 
 export class ApiError extends Error {
   constructor(
@@ -32,20 +33,39 @@ async function request<T>(path: string, options?: RequestInit, canRetry = true):
     ...options,
   });
 
-  if (res.status === 401 && canRetry && !path.startsWith('/api/auth/')) {
-    const newToken = await tryRefreshAccessToken();
-    if (newToken) {
-      return request<T>(path, options, false);
-    }
-    authStore.clear();
-    redirectToLoginWithCurrentPath();
-    throw new ApiError('인증이 만료되었습니다. 다시 로그인해주세요.', 401);
-  }
+  const isAuthPath = path.startsWith('/api/auth/');
+  const isUnauthorized = res.status === 401 || res.status === 403;
+  if (isUnauthorized && !isAuthPath) {
+    const status = authStore.getStatus();
+    authDebug('api:unauthorized', { path, status, httpStatus: res.status, canRetry });
 
-  if (res.status === 403 && !path.startsWith('/api/auth/')) {
+    // checking 동안은 성급하게 로그인으로 보내지 말고 refresh 결과를 기다려본다.
+    if (canRetry) {
+      const newToken = await refreshAccessTokenSingleFlight(`api:${res.status}:${path}`);
+      if (newToken) {
+        authDebug('api:retry-after-refresh', { path });
+        return request<T>(path, options, false);
+      }
+
+      // checking이 끝나기 전이면 provider refresh를 기다렸다가 1회만 더 시도
+      if (status === 'checking' && !authStore.isSessionInitDone()) {
+        authDebug('api:wait-session-init', { path });
+        await authStore.whenSessionInitialized();
+        const tokenAfterInit = authStore.getAccessToken();
+        if (tokenAfterInit) {
+          authDebug('api:retry-after-init', { path });
+          return request<T>(path, options, false);
+        }
+      }
+    }
+
     authStore.clear();
+    authDebug('api:redirect-login', { path, httpStatus: res.status });
     redirectToLoginWithCurrentPath();
-    throw new ApiError('로그인이 필요합니다. 다시 로그인해주세요.', 403);
+    throw new ApiError(
+      res.status === 401 ? '인증이 만료되었습니다. 다시 로그인해주세요.' : '로그인이 필요합니다. 다시 로그인해주세요.',
+      res.status,
+    );
   }
 
   const text = await res.text();
@@ -68,43 +88,6 @@ async function request<T>(path: string, options?: RequestInit, canRetry = true):
   }
 
   return body as T;
-}
-
-async function tryRefreshAccessToken(): Promise<string | null> {
-  if (!refreshPromise) {
-    refreshPromise = (async () => {
-      try {
-        const res = await fetch(`${BASE_URL}/api/auth/refresh`, {
-          method: 'POST',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({}),
-        });
-        if (!res.ok) return null;
-
-        const text = await res.text();
-        const body = text
-          ? (() => {
-              try {
-                return JSON.parse(text) as ApiResponse<{ accessToken: string }>;
-              } catch {
-                return null;
-              }
-            })()
-          : null;
-
-        const newToken = body?.result?.accessToken ?? null;
-        if (newToken) authStore.setAccessToken(newToken);
-        return newToken;
-      } catch {
-        return null;
-      } finally {
-        refreshPromise = null;
-      }
-    })();
-  }
-
-  return refreshPromise;
 }
 
 function redirectToLoginWithCurrentPath() {

--- a/briefin/src/app/(CommonLayout)/feed/layout.tsx
+++ b/briefin/src/app/(CommonLayout)/feed/layout.tsx
@@ -1,29 +1,24 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
-import { useAuthSessionVersion } from '@/providers/AuthSessionProvider';
-import { authStore } from '@/store/authStore';
+import { useAuthStatus } from '@/providers/AuthSessionProvider';
 
 export default function FeedProtectedLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
-  const authSessionVersion = useAuthSessionVersion();
-  const [ready, setReady] = useState(false);
+  const status = useAuthStatus();
 
   useEffect(() => {
-    if (authSessionVersion === 0) return;
-    const authed = authStore.isAuthenticated();
-    if (!authed) {
-      setReady(false);
+    if (status === 'checking') return;
+    if (status !== 'authenticated') {
       const redirect = pathname || '/feed';
       router.replace(`/login?redirect=${encodeURIComponent(redirect)}`);
       return;
     }
-    setReady(true);
-  }, [authSessionVersion, pathname, router]);
+  }, [status, pathname, router]);
 
-  if (!ready) return null;
+  if (status !== 'authenticated') return null;
 
   return <>{children}</>;
 }

--- a/briefin/src/app/(CommonLayout)/reels/layout.tsx
+++ b/briefin/src/app/(CommonLayout)/reels/layout.tsx
@@ -1,29 +1,24 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
-import { useAuthSessionVersion } from '@/providers/AuthSessionProvider';
-import { authStore } from '@/store/authStore';
+import { useAuthStatus } from '@/providers/AuthSessionProvider';
 
 export default function ReelsProtectedLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
-  const authSessionVersion = useAuthSessionVersion();
-  const [ready, setReady] = useState(false);
+  const status = useAuthStatus();
 
   useEffect(() => {
-    if (authSessionVersion === 0) return;
-    const authed = authStore.isAuthenticated();
-    if (!authed) {
-      setReady(false);
+    if (status === 'checking') return;
+    if (status !== 'authenticated') {
       const redirect = pathname || '/reels';
       router.replace(`/login?redirect=${encodeURIComponent(redirect)}`);
       return;
     }
-    setReady(true);
-  }, [authSessionVersion, pathname, router]);
+  }, [status, pathname, router]);
 
-  if (!ready) return null;
+  if (status !== 'authenticated') return null;
 
   return <>{children}</>;
 }

--- a/briefin/src/components/home/HomeWatchlistSection.tsx
+++ b/briefin/src/components/home/HomeWatchlistSection.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useState } from 'react';
 import { useWatchlist } from '@/hooks/useUser';
+import { useAuthStatus } from '@/providers/AuthSessionProvider';
 import type { WatchlistCompany } from '@/types/mypage';
 
 function CompanyLogo({ company }: { company: WatchlistCompany }) {
@@ -13,10 +14,11 @@ function CompanyLogo({ company }: { company: WatchlistCompany }) {
     : (company.logoUrl ?? null);
 
   if (logoUrl && !imgError) {
+    const altText = company.companyName?.trim() ? `${company.companyName} 로고` : '회사 로고';
     return (
       <Image
         src={logoUrl}
-        alt={company.companyName}
+        alt={altText}
         width={40}
         height={40}
         className="object-cover"
@@ -33,11 +35,30 @@ function CompanyLogo({ company }: { company: WatchlistCompany }) {
 }
 
 export default function HomeWatchlistSection() {
-  const { data: watchlist, isLoading } = useWatchlist();
+  const status = useAuthStatus();
+  const { data: watchlist, isLoading } = useWatchlist({ enabled: status === 'authenticated' });
 
   return (
     <div className="rounded-card border border-surface-border bg-surface-white p-20pxr">
       <p className="text-[15px] font-black text-text-primary">👀 내 관심 기업</p>
+
+      {status === 'checking' && (
+        <ul className="mt-8pxr divide-y divide-surface-border">
+          {[...Array(3)].map((_, i) => (
+            <li key={i} className="flex items-center gap-12pxr py-12pxr">
+              <div className="h-40pxr w-40pxr shrink-0 animate-pulse rounded-full bg-surface-border" />
+              <div className="flex-1 space-y-6pxr">
+                <div className="h-12pxr w-24 animate-pulse rounded bg-surface-border" />
+                <div className="h-10pxr w-16 animate-pulse rounded bg-surface-border" />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {status === 'unauthenticated' && (
+        <p className="py-20pxr text-center text-[13px] text-text-muted">로그인하면 관심 기업을 볼 수 있어요</p>
+      )}
 
       {isLoading && (
         <ul className="mt-8pxr divide-y divide-surface-border">

--- a/briefin/src/hooks/useUser.ts
+++ b/briefin/src/hooks/useUser.ts
@@ -40,10 +40,11 @@ export function useRecentNews(page = 1) {
 }
 
 // 관심 기업 목록
-export function useWatchlist() {
+export function useWatchlist(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: userKeys.watchlist(),
     queryFn: fetchWatchlist,
+    enabled: options?.enabled,
   });
 }
 

--- a/briefin/src/lib/authDebug.ts
+++ b/briefin/src/lib/authDebug.ts
@@ -1,0 +1,14 @@
+export function authDebug(event: string, data?: Record<string, unknown>) {
+  if (process.env.NODE_ENV === 'production') return;
+  const payload = data ? ` ${safeStringify(data)}` : '';
+  console.debug(`[auth] ${event}${payload}`);
+}
+
+function safeStringify(data: Record<string, unknown>) {
+  try {
+    return JSON.stringify(data);
+  } catch {
+    return '[unserializable]';
+  }
+}
+

--- a/briefin/src/lib/refreshSession.ts
+++ b/briefin/src/lib/refreshSession.ts
@@ -1,0 +1,68 @@
+import { authStore } from '@/store/authStore';
+import { authDebug } from '@/lib/authDebug';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080';
+
+let inFlight: Promise<string | null> | null = null;
+
+/**
+ * refreshToken 쿠키 기반으로 accessToken을 재발급한다.
+ * - 반드시 single-flight
+ * - apiClient를 쓰지 않고 raw fetch 사용(401 처리와 재귀 방지)
+ */
+export async function refreshAccessTokenSingleFlight(reason: string): Promise<string | null> {
+  if (inFlight) {
+    authDebug('refresh:join', { reason });
+    return inFlight;
+  }
+
+  authDebug('refresh:start', { reason });
+  inFlight = (async () => {
+    try {
+      const res = await fetch(`${BASE_URL}/api/auth/refresh`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      if (!res.ok) {
+        authDebug('refresh:fail-http', { reason, status: res.status });
+        return null;
+      }
+
+      const text = await res.text();
+      const body = text
+        ? (() => {
+            try {
+              return JSON.parse(text) as { result?: { accessToken?: string } };
+            } catch {
+              return null;
+            }
+          })()
+        : null;
+
+      const token = body?.result?.accessToken ?? null;
+      if (token) {
+        authStore.setAccessToken(token);
+        authStore.setStatus('authenticated');
+        authDebug('refresh:success', { reason });
+      } else {
+        authDebug('refresh:fail-no-token', { reason });
+      }
+      return token;
+    } catch {
+      authDebug('refresh:fail-exception', { reason });
+      return null;
+    } finally {
+      inFlight = null;
+    }
+  })();
+
+  return inFlight;
+}
+
+export function isRefreshInFlight() {
+  return !!inFlight;
+}
+

--- a/briefin/src/providers/AuthSessionProvider.tsx
+++ b/briefin/src/providers/AuthSessionProvider.tsx
@@ -1,29 +1,42 @@
 'use client';
 
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
-import { refresh } from '@/api/authApi';
-import { authStore } from '@/store/authStore';
+import { authStore, type AuthStatus } from '@/store/authStore';
+import { authDebug } from '@/lib/authDebug';
+import { refreshAccessTokenSingleFlight } from '@/lib/refreshSession';
 
-
-
-const AuthSessionVersionContext = createContext(0);
+type AuthSessionContextValue = { version: number; status: AuthStatus };
+const AuthSessionContext = createContext<AuthSessionContextValue>({ version: 0, status: 'checking' });
 
 export function useAuthSessionVersion() {
-  return useContext(AuthSessionVersionContext);
+  return useContext(AuthSessionContext).version;
+}
+
+export function useAuthStatus() {
+  return useContext(AuthSessionContext).status;
 }
 
 export default function AuthSessionProvider({ children }: { children: ReactNode }) {
   const [version, setVersion] = useState(0);
+  const [status, setStatus] = useState<AuthStatus>('checking');
 
   useEffect(() => {
     let cancelled = false;
+    authStore.beginSessionInit();
+    authStore.setStatus('checking');
+    authDebug('session:init-start');
+
     (async () => {
       try {
-        const { accessToken } = await refresh();
-        if (!cancelled) authStore.setAccessToken(accessToken);
+        await refreshAccessTokenSingleFlight('session-init');
       } catch {
+        // ignore
       } finally {
-        if (!cancelled) setVersion((v) => v + 1);
+        if (!cancelled) {
+          authStore.finishSessionInit();
+          authDebug('session:init-done', { status: authStore.getStatus() });
+          setVersion((v) => v + 1);
+        }
       }
     })();
     return () => {
@@ -31,5 +44,19 @@ export default function AuthSessionProvider({ children }: { children: ReactNode 
     };
   }, []);
 
-  return <AuthSessionVersionContext.Provider value={version}>{children}</AuthSessionVersionContext.Provider>;
+  useEffect(() => {
+    const unsub = authStore.subscribe(() => {
+      setStatus(authStore.getStatus());
+      setVersion((v) => v + 1);
+    });
+    return () => {
+      unsub();
+    };
+  }, []);
+
+  return (
+    <AuthSessionContext.Provider value={{ version, status }}>
+      {children}
+    </AuthSessionContext.Provider>
+  );
 }

--- a/briefin/src/store/authStore.ts
+++ b/briefin/src/store/authStore.ts
@@ -1,6 +1,17 @@
 let accessToken: string | null = null;
 
+export type AuthStatus = 'checking' | 'authenticated' | 'unauthenticated';
+let authStatus: AuthStatus = 'checking';
+let sessionInitDone = false;
+let sessionInitPromise: Promise<void> | null = null;
+let sessionInitResolve: (() => void) | null = null;
 
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+function emit() {
+  for (const l of listeners) l();
+}
 
 export const authStore = {
   getAccessToken() {
@@ -9,13 +20,61 @@ export const authStore = {
 
   setAccessToken(token: string | null) {
     accessToken = token;
+    authStatus = token ? 'authenticated' : authStatus === 'checking' ? 'checking' : 'unauthenticated';
+    emit();
   },
 
   clear() {
     accessToken = null;
+    authStatus = 'unauthenticated';
+    emit();
   },
 
   isAuthenticated() {
     return !!accessToken;
+  },
+
+  getStatus(): AuthStatus {
+    return authStatus;
+  },
+
+  setStatus(status: AuthStatus) {
+    authStatus = status;
+    emit();
+  },
+
+  beginSessionInit() {
+    authStatus = 'checking';
+    sessionInitDone = false;
+    sessionInitPromise =
+      sessionInitPromise ??
+      new Promise<void>((resolve) => {
+        sessionInitResolve = resolve;
+      });
+    emit();
+    return sessionInitPromise;
+  },
+
+  finishSessionInit() {
+    sessionInitDone = true;
+    if (!accessToken && authStatus === 'checking') authStatus = 'unauthenticated';
+    sessionInitResolve?.();
+    sessionInitResolve = null;
+    sessionInitPromise = null;
+    emit();
+  },
+
+  isSessionInitDone() {
+    return sessionInitDone;
+  },
+
+  whenSessionInitialized(): Promise<void> {
+    if (sessionInitDone) return Promise.resolve();
+    return sessionInitPromise ?? Promise.resolve();
+  },
+
+  subscribe(listener: Listener) {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
   },
 };


### PR DESCRIPTION
## #️⃣연관된 이슈
#인증 #세션 #refresh

---

## 📝작업 내용

새로고침 시 로그인 상태가 풀리는 문제를 해결하기 위해  
JWT 인증 흐름의 **refresh 처리 및 세션 초기화 로직을 개선**했습니다.

### 🎯 주요 변경 사항

- refresh 중복 호출 방지 (single-flight 적용)
- 세션 초기화 상태(`checking`) 도입
- refresh 완료 전 보호 API 호출 방지
- 401/403 발생 시 즉시 로그인 리다이렉트하지 않고 refresh 후 재시도하도록 개선
- refreshToken 쿠키 설정 안정화 (SameSite, Path 등 명시)
- refresh token rotation 시 동시 요청에 대한 멱등 처리 적용 (백엔드)

### 🔧 개선 효과

- 새로고침 시 로그인 상태 안정적으로 유지
- refresh 요청이 2번 이상 발생하던 문제 해결
- 보호 API 호출 시 발생하던 race condition 제거
- 인증 흐름 전반의 UX 안정성 향상

---

### 🖼️ 스크린샷 (선택)

- (선택) Network 탭에서 refresh 1회만 호출되고 이후 API 정상 동작 캡처 첨부 가능

---

## 💬리뷰 요구사항

- refresh single-flight 처리 방식이 적절한지 확인 부탁드립니다.
- 세션 초기화(`checking`) 상태 도입으로 인한 사이드 이펙트(렌더 지연 등)가 없는지 검토 부탁드립니다.
- 401/403 처리 로직에서 refresh 재시도 후 redirect 흐름이 자연스러운지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 세션 초기화 중 로딩 상태 추가
  * 비인증 사용자를 위한 로그인 프롬프트 및 안내 표시

* **버그 수정**
  * 토큰 갱신 메커니즘의 안정성 개선
  * 인증 오류(401/403) 처리 개선
  * 세션 확인 중 동시 요청 처리 개선
  * 보호된 페이지 접근 시 로그인 리다이렉트 신뢰성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->