### PR TITLE
fix: 뉴스 검색 시 result 페이지로 바로 이동

### DIFF
--- a/briefin/src/app/(CommonLayout)/news/page.tsx
+++ b/briefin/src/app/(CommonLayout)/news/page.tsx
@@ -9,7 +9,7 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ c
   return (
     <main className="min-h-screen bg-surface-bg py-36pxr">
       <h1 className="fonts-heading3 pb-16pxr">뉴스</h1>
-      <SearchComponent />
+      <SearchComponent searchPath="/news/search/result" />
       <TickerNav />
       <div className="flex flex-col gap-16pxr lg:flex-row lg:items-start">
         {/* Left: news list */}

--- a/briefin/src/app/(CommonLayout)/news/search/result/page.tsx
+++ b/briefin/src/app/(CommonLayout)/news/search/result/page.tsx
@@ -1,10 +1,7 @@
-import { Suspense } from 'react';
+'use client';
+
 import SearchContent from '@/components/news/SearchContent';
 
 export default function SearchPage() {
-  return (
-    <Suspense fallback={<main className="relative flex h-full w-full flex-col pt-36pxr" />}>
-      <SearchContent />
-    </Suspense>
-  );
+  return <SearchContent />;
 }

--- a/briefin/src/components/common/SearchComponent.tsx
+++ b/briefin/src/components/common/SearchComponent.tsx
@@ -10,7 +10,7 @@ export function SearchComponent({
   const router = useRouter();
 
   const handleSearch = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
       const value = e.currentTarget.value;
       if (value.trim()) {
         router.push(`${searchPath}?q=${encodeURIComponent(value)}`);
@@ -36,7 +36,7 @@ export function SearchComponent({
         className="w-full bg-transparent p-5pxr text-text-primary placeholder:text-text-muted focus:outline-none"
         type="text"
         placeholder={placeholder}
-        onKeyDown={handleSearch}
+        onKeyUp={handleSearch}
       />
     </div>
   );


### PR DESCRIPTION
## #️⃣ Issue Number

128

## 📝 변경사항

뉴스 검색 시 result 페이지로 바로 이동

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 뉴스 검색 시 기존 search 페이지로 이동하던 것을 result페이지로 바로 이동하도록 변경함


## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [x] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 한글 등 IME 입력 중 Enter 키로 검색이 실행되는 문제를 해결했습니다.
  * 뉴스 검색 결과 페이지의 로딩 성능을 개선했습니다.

* **개선 사항**
  * 뉴스 페이지의 검색 경로 설정을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->