### PR TITLE
불필요한 refresh api 호출 제거

### DIFF
--- a/briefin/src/api/client.ts
+++ b/briefin/src/api/client.ts
@@ -1,6 +1,6 @@
 import { authStore } from '@/store/authStore';
 import { authDebug } from '@/lib/authDebug';
-import { refreshAccessTokenSingleFlight } from '@/lib/refreshSession';
+import { markExplicitLogout, refreshAccessTokenSingleFlight } from '@/lib/refreshSession';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080';
 
@@ -60,6 +60,8 @@ async function request<T>(path: string, options?: RequestInit, canRetry = true):
     }
 
     authStore.clear();
+    // 여기까지 왔다는 건 "refresh로도 복구 불가" → 이후 refresh 네트워크 호출을 막는다.
+    markExplicitLogout();
     authDebug('api:redirect-login', { path, httpStatus: res.status });
     redirectToLoginWithCurrentPath();
     throw new ApiError(

--- a/briefin/src/components/common/Header.tsx
+++ b/briefin/src/components/common/Header.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { logout as logoutApi } from '@/api/authApi';
+import { markExplicitLogout } from '@/lib/refreshSession';
 import { NAV_ITEMS } from '@/constants/header';
 import { useAuthSessionVersion } from '@/providers/AuthSessionProvider';
 import { authStore } from '@/store/authStore';
@@ -45,6 +46,7 @@ export default function Header() {
     } catch {
       /* 서버 오류여도 클라이언트 세션은 종료 */
     } finally {
+      markExplicitLogout();
       authStore.clear();
       setIsLoggedIn(false);
       setUserEmail(null);

--- a/briefin/src/components/mypage/AccountSection.tsx
+++ b/briefin/src/components/mypage/AccountSection.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import WithdrawConfirmModal from '@/components/auth/WithdrawConfirmModal';
 import { deleteMyAccount } from '@/api/userApi';
+import { markExplicitLogout } from '@/lib/refreshSession';
 import { authStore } from '@/store/authStore';
 import { useMyInfo } from '@/hooks/useUser';
 
@@ -21,6 +22,7 @@ export default function AccountSection() {
 
     try {
       await deleteMyAccount();
+      markExplicitLogout();
       authStore.clear();
       setShowWithdrawModal(false);
       router.replace('/');

--- a/briefin/src/hooks/useAuth.ts
+++ b/briefin/src/hooks/useAuth.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { login, signup } from '@/api/authApi';
+import { clearExplicitLogout, markMayHaveRefresh } from '@/lib/refreshSession';
 import { authStore } from '@/store/authStore';
 
 export function useLogin(redirectTo?: string) {
@@ -8,6 +9,8 @@ export function useLogin(redirectTo?: string) {
   return useMutation({
     mutationFn: login,
     onSuccess: (data) => {
+      clearExplicitLogout();
+      markMayHaveRefresh();
       authStore.setAccessToken(data.accessToken);
       const target = redirectTo && redirectTo.startsWith('/') ? redirectTo : '/';
       router.push(target);

--- a/briefin/src/lib/refreshSession.ts
+++ b/briefin/src/lib/refreshSession.ts
@@ -3,6 +3,87 @@ import { authDebug } from '@/lib/authDebug';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080';
 
+const EXPLICIT_LOGOUT_KEY = 'briefin:auth:explicitLogout';
+const MAY_HAVE_REFRESH_KEY = 'briefin:auth:mayHaveRefresh';
+
+export function markMayHaveRefresh(): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(MAY_HAVE_REFRESH_KEY, '1');
+  } catch {
+    /* ignore */
+  }
+}
+
+export function clearMayHaveRefresh(): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.removeItem(MAY_HAVE_REFRESH_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+function getMayHaveRefresh(): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  try {
+    return localStorage.getItem(MAY_HAVE_REFRESH_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/** 로그아웃 직후 ~ 다시 로그인하기 전까지 refresh 네트워크 호출을 막는다(풀 리로드 포함). */
+export function markExplicitLogout(): void {
+  if (typeof sessionStorage === 'undefined') return;
+  try {
+    sessionStorage.setItem(EXPLICIT_LOGOUT_KEY, '1');
+  } catch {
+    /* ignore */
+  }
+
+  // 명시적 로그아웃이면 더 이상 refresh 시도할 이유가 없다.
+  clearMayHaveRefresh();
+}
+
+export function clearExplicitLogout(): void {
+  if (typeof sessionStorage === 'undefined') return;
+  try {
+    sessionStorage.removeItem(EXPLICIT_LOGOUT_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+function shouldSkipRefreshNetwork(): boolean {
+  if (typeof sessionStorage !== 'undefined') {
+    try {
+      if (sessionStorage.getItem(EXPLICIT_LOGOUT_KEY) === '1') {
+        return true;
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // 과거에 로그인/refresh 성공 이력이 전혀 없으면 refresh 네트워크 호출을 하지 않는다.
+  // (HttpOnly refresh 쿠키 존재 여부는 JS로 알 수 없으므로, "로그인 경험이 있는 브라우저"만 시도)
+  if (!getMayHaveRefresh()) {
+    return true;
+  }
+
+  // session-init 이후 비로그인으로 확정된 상태에서는 refresh 재시도가 불필요(401 연쇄 방지)
+  if (
+    authStore.isSessionInitDone() &&
+    authStore.getStatus() === 'unauthenticated' &&
+    !authStore.getAccessToken()
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
 let inFlight: Promise<string | null> | null = null;
 
 /**
@@ -11,6 +92,11 @@ let inFlight: Promise<string | null> | null = null;
  * - apiClient를 쓰지 않고 raw fetch 사용(401 처리와 재귀 방지)
  */
 export async function refreshAccessTokenSingleFlight(reason: string): Promise<string | null> {
+  if (shouldSkipRefreshNetwork()) {
+    authDebug('refresh:skip', { reason });
+    return null;
+  }
+
   if (inFlight) {
     authDebug('refresh:join', { reason });
     return inFlight;
@@ -44,6 +130,8 @@ export async function refreshAccessTokenSingleFlight(reason: string): Promise<st
 
       const token = body?.result?.accessToken ?? null;
       if (token) {
+        clearExplicitLogout();
+        markMayHaveRefresh();
         authStore.setAccessToken(token);
         authStore.setStatus('authenticated');
         authDebug('refresh:success', { reason });


### PR DESCRIPTION
## #️⃣ Issue Number

#152 

📝 변경사항
🎯 핵심 변경 사항 (Key Changes)

로그아웃/비로그인 확정 상태에서는 refresh 네트워크 호출을 중앙에서 차단
하도록 가드 로직 추가 (
refreshSession
)

로그아웃/탈퇴/401 강제 로그아웃 경로에서 “명시적 로그아웃” 플래그를 세팅
해 이후
session-init
/401 재시도에서도 refresh가 발생하지 않게 수정
🔍 주안점 & 리뷰 포인트
“로그아웃 상태”의 정의를 명시적 로그아웃(사용자 액션) + 강제 로그아웃(401/403로 복구 실패)로 잡고, 이 상태에서는 refresh가 절대 나가지 않도록 한 정책이 요구사항과 일치하는지 확인 부탁드립니다.
localStorage의 mayHaveRefresh(과거 로그인/refresh 성공 이력)로 “refresh 시도 대상 브라우저”를 제한했는데, 이 기준이 서비스 정책상 적절한지 리뷰 부탁드립니다.
🖼️ 스크린샷 / 테스트 결과
수동 테스트: 로그아웃 후 페이지 이동/새로고침 시 Network에서 POST /api/auth/refresh 호출이 발생하지 않음
로그 확인(개발환경): [auth] refresh:skip 이벤트로 스킵 경로 확인 가능
🛠️ PR 유형

✨ 새로운 기능 추가

🐛 버그 수정

💄 UI/UX 디자인 변경

♻️ 리팩토링

📝 문서 수정 (Docs)

✅ 테스트 추가/수정

🔧 빌드/패키지 매니저/CI 설정 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 로그아웃 후 불필요한 네트워크 요청을 방지하도록 세션 관리 로직 개선
  * 계정 삭제 및 토큰 만료 시나리오에서 로그아웃 상태 처리 개선
  * 로그인 성공 시 세션 복구 상태 초기화로 인증 플로우 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->