### PR TITLE
feat: 뉴스 히스토리 탭 제거 및 단일 뷰로 통합, 최신순 정렬

### DIFF
--- a/briefin/src/app/(CommonLayout)/companies/[id]/page.tsx
+++ b/briefin/src/app/(CommonLayout)/companies/[id]/page.tsx
@@ -15,7 +15,7 @@ import { fetchCompanyNews, toNewsItem } from '@/api/newsApi';
 import { fetchDisclosureList } from '@/api/disclosureApi';
 import type { NewsItem } from '@/types/news';
 import type { DisclosureListItem } from '@/types/disclosure';
-import { TIMELINE_TAGS, MOCK_TIMELINE_ITEMS } from '@/mocks/timelineData';
+import { MOCK_TIMELINE_ITEMS } from '@/mocks/timelineData';
 import { useStockPrice } from '@/api/hook/useStockPrice';
 import { useAuthSessionVersion, useAuthStatus } from '@/providers/AuthSessionProvider';
 import CompanyDetailSkeleton from '@/components/companies/CompanyDetailSkeleton';
@@ -27,7 +27,6 @@ export default function CompanyDetailPage() {
   const [activeTab, setActiveTab] = useState<CompanyDetailTab>('관련 뉴스');
   const [company, setCompany] = useState<CompanyDetail | null>(null);
   const [loading, setLoading] = useState(true);
-  const [activeTimelineTag, setActiveTimelineTag] = useState(TIMELINE_TAGS[0]);
   const [news, setNews] = useState<NewsItem[]>([]);
   const [newsLoading, setNewsLoading] = useState(false);
   const [disclosures, setDisclosures] = useState<DisclosureListItem[]>([]);
@@ -256,12 +255,7 @@ export default function CompanyDetailPage() {
             buttonLabel={isSubscribed ? '알림 해제하기' : '알림 설정하기'}
             onButtonClick={handleAlertClick}
           />
-          <NewsTimeline
-            tags={TIMELINE_TAGS}
-            activeTag={activeTimelineTag}
-            onTagChange={setActiveTimelineTag}
-            items={MOCK_TIMELINE_ITEMS}
-          />
+          <NewsTimeline items={MOCK_TIMELINE_ITEMS} />
         </div>
       </div>
     </div>

--- a/briefin/src/components/common/NewsTimeline.tsx
+++ b/briefin/src/components/common/NewsTimeline.tsx
@@ -3,9 +3,7 @@
 import Link from 'next/link';
 import { NewsTimelineProps } from '@/types/timeline';
 
-export default function NewsTimeline({ tags, activeTag, onTagChange, items, loading }: NewsTimelineProps) {
-  const filtered = items.filter((item) => item.tag === activeTag);
-
+export default function NewsTimeline({ items, loading }: NewsTimelineProps) {
   return (
     <div className="rounded-card border border-[#E5E7EB] bg-surface-white">
       {/* Header */}
@@ -13,40 +11,16 @@ export default function NewsTimeline({ tags, activeTag, onTagChange, items, load
         <p className="text-[15px] font-bold text-text-primary">뉴스 히스토리</p>
       </div>
 
-      {/*
-        태그 잘림 방지: overflow-x 컨테이너가 overflow-y도 암묵적으로 clip하므로
-        outer div에 py 여유를 두고 inner에서 실제 overflow-x를 처리
-      */}
-      <div className="mt-12pxr px-20pxr py-4pxr">
-        <div className="flex gap-8pxr overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          {tags.map((tag) => {
-            const isActive = tag === activeTag;
-            return (
-              <button
-                key={tag}
-                type="button"
-                onClick={() => onTagChange(tag)}
-                className={[
-                  'shrink-0 rounded-pill border px-12pxr py-6pxr text-[12px] font-bold transition-colors',
-                  isActive ? 'border-primary bg-primary text-white' : 'border-[#E5E7EB] bg-[#F9FAFB] text-text-sub',
-                ].join(' ')}>
-                {tag}
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
       {/* Timeline */}
-      <div className="border-t border-[#E5E7EB] px-20pxr py-16pxr">
+      <div className="border-t border-[#E5E7EB] mt-12pxr px-20pxr py-16pxr">
         {loading ? (
           <TimelineSkeleton />
-        ) : filtered.length === 0 ? (
+        ) : items.length === 0 ? (
           <p className="py-12pxr text-center text-[12px] text-text-muted">관련 뉴스가 없습니다.</p>
         ) : (
           <div className="flex flex-col">
-            {filtered.map((item, idx) => {
-              const isLast = idx === filtered.length - 1;
+            {items.map((item, idx) => {
+              const isLast = idx === items.length - 1;
               const rowKey = item.newsId ?? `${item.date}-${idx}`;
 
               const inner = (

--- a/briefin/src/components/news/NewsDetailClient.tsx
+++ b/briefin/src/components/news/NewsDetailClient.tsx
@@ -42,18 +42,18 @@ export default function NewsDetailClient({ data }: { data: NewsDetailResponse })
 
   const { data: timelineData, isLoading: timelineLoading } = useNewsTimeline(data.newsId);
 
-  const timelineItems: NewsTimelineItem[] = (timelineData ?? []).map((item) => ({
-    id: item.newsId,
-    date: item.publishedAt ? item.publishedAt.slice(0, 10).replace(/-/g, '.') : '',
-    title: item.title,
-    source: item.press,
-    tag: item.category ?? '기타',
-    isLatest: item.isCurrent,
-    newsId: item.newsId,
-  }));
-
-  const timelineTags = [...new Set(timelineItems.map((i) => i.tag))];
-  const effectiveTag = timelineTags.includes(activeTimelineTag) ? activeTimelineTag : (timelineTags[0] ?? '');
+  const timelineItems: NewsTimelineItem[] = (timelineData ?? [])
+    .map((item) => ({
+      id: item.newsId,
+      date: item.publishedAt ? item.publishedAt.slice(0, 10).replace(/-/g, '.') : '',
+      title: item.title,
+      source: item.press,
+      tag: item.category ?? '기타',
+      isLatest: item.isCurrent,
+      newsId: item.newsId,
+      publishedAt: item.publishedAt ?? '',
+    }))
+    .sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
 
   const relatedCompanies = (data.relatedCompanies ?? []).map((company) => ({
     id: company.companyId,
@@ -111,13 +111,7 @@ export default function NewsDetailClient({ data }: { data: NewsDetailResponse })
         </article>
 
         <div className="flex w-full flex-col gap-16pxr lg:w-[320px] lg:shrink-0">
-          <NewsTimeline
-            tags={timelineTags}
-            activeTag={effectiveTag}
-            onTagChange={setActiveTimelineTag}
-            items={timelineItems}
-            loading={timelineLoading}
-          />
+          <NewsTimeline items={timelineItems} loading={timelineLoading} />
           <NewsSidebar relatedNews={relatedNews} relatedCompanies={relatedCompanies} relatedNewsLoading={relatedNewsLoading} />
         </div>
       </div>

--- a/briefin/src/types/timeline.ts
+++ b/briefin/src/types/timeline.ts
@@ -3,20 +3,13 @@ export interface NewsTimelineItem {
   date: string;       // e.g. "2025.03.27"
   title: string;
   source: string;
-  tag: string;        // which tag this item belongs to
+  tag: string;
   isLatest?: boolean;
-  newsId?: string;    // for navigation after API integration
+  newsId?: string;
+  publishedAt?: string;
 }
 
 export interface NewsTimelineProps {
-  /** 필터 태그 목록 */
-  tags: string[];
-  /** 현재 선택된 태그 */
-  activeTag: string;
-  /** 태그 변경 핸들러 */
-  onTagChange: (tag: string) => void;
-  /** 타임라인 아이템 목록 (activeTag로 이미 필터된 목록을 넘기거나 전체를 넘겨도 됨) */
   items: NewsTimelineItem[];
-  /** 로딩 스켈레톤 표시 여부 */
   loading?: boolean;
 }


### PR DESCRIPTION
## #️⃣ Issue Number

157

## 📝 변경사항

뉴스 히스토리 컴포넌트 UI 변경

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 카테고리 삭제
- [ ] 뉴스 정렬 방식 최신순으로 변경

### 🖼️ 스크린샷 / 테스트 결과

<img width="839" height="684" alt="image" src="https://github.com/user-attachments/assets/ba98c73c-c778-4c24-be11-8fb86cb8c078" />

---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경사항**
  * 타임라인에서 태그 필터링 기능 제거 - 사용자가 더 이상 태그로 뉴스를 필터링할 수 없습니다
  * 타임라인 항목이 발행 날짜 기준으로 정렬되도록 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->