### PR TITLE
feat: 피드 페이지 매거진 그리드 UI로 개편

### DIFF
--- a/briefin/src/app/(CommonLayout)/feed/page.tsx
+++ b/briefin/src/app/(CommonLayout)/feed/page.tsx
@@ -1,45 +1,89 @@
 'use client';
 
-import NewsCard from '@/components/news/NewsCard';
+import Link from 'next/link';
 import AlertBanner from '@/components/common/AlertBanner';
+import FeedHeroCard from '@/components/feed/FeedHeroCard';
+import FeedGridCard from '@/components/feed/FeedGridCard';
 import { useFeed } from '@/hooks/useFeed';
-import { mapNewsItem } from '@/lib/viewMappers';
+
+function FeedSkeleton() {
+  return (
+    <div className="flex flex-col gap-16pxr">
+      <div className="h-[300px] animate-pulse rounded-card bg-surface-muted sm:h-[380px]" />
+      <div className="grid grid-cols-2 gap-14pxr sm:grid-cols-3">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <div key={i} className="flex flex-col overflow-hidden rounded-card border border-surface-border">
+            <div className="h-[140px] animate-pulse bg-surface-muted" />
+            <div className="flex flex-col gap-8pxr p-16pxr">
+              <div className="h-4 w-full animate-pulse rounded bg-surface-muted" />
+              <div className="h-4 w-3/4 animate-pulse rounded bg-surface-muted" />
+              <div className="mt-4pxr h-3 w-1/2 animate-pulse rounded bg-surface-muted" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export default function FeedPage() {
   const { data, isLoading, isError } = useFeed();
 
+  const hero = data?.[0];
+  const grid = data?.slice(1) ?? [];
+
   return (
     <main className="min-h-screen bg-surface-bg py-36pxr">
       {/* Header */}
-      <div className="pb-16pxr">
+      <div className="pb-20pxr">
         <h1 className="fonts-heading3">내 피드</h1>
-        <p className="mt-4pxr text-[14px] text-text-muted">관심 등록한 기업의 소식만 모았어요</p>
+        <p className="mt-4pxr text-[14px] text-text-muted">관심 등록한 기업의 최신 소식</p>
       </div>
 
-      {/* Body */}
-      <div className="flex flex-col gap-16pxr lg:flex-row lg:items-start">
-        {/* Left: news list */}
-        <div className="flex flex-1 flex-col gap-14pxr">
-          {isLoading && <p className="fonts-label py-40pxr text-center text-text-muted">뉴스를 불러오는 중...</p>}
-          {isError && <p className="fonts-label py-40pxr text-center text-text-muted">뉴스를 불러오지 못했습니다.</p>}
-          {data && data.length === 0 && (
-            <p className="fonts-label py-40pxr text-center text-text-muted">관심 기업의 뉴스가 없습니다.</p>
-          )}
-          {data?.map((item) => (
-            <NewsCard key={item.newsId} news={mapNewsItem(item)} />
-          ))}
-        </div>
+      {isLoading && <FeedSkeleton />}
 
-        {/* Right sidebar */}
-        <div className="flex flex-col gap-16pxr lg:w-96 lg:shrink-0">
-          <AlertBanner
-            title="관심 기업을 더 추가해보세요"
-            description="더 많은 기업을 등록할수록 내 피드가 풍성해져요."
-            buttonLabel="관심 기업 추가하기"
-            buttonHref="/onboarding"
-          />
+      {isError && (
+        <p className="fonts-label py-40pxr text-center text-text-muted">뉴스를 불러오지 못했습니다.</p>
+      )}
+
+      {data && data.length === 0 && (
+        <div className="flex flex-col items-center justify-center gap-12pxr py-60pxr text-center">
+          <span className="text-[48px]">📭</span>
+          <p className="fonts-body font-medium text-text-primary">아직 관심 기업이 없어요</p>
+          <p className="fonts-label text-text-muted">기업을 등록하면 맞춤 뉴스를 받아볼 수 있어요.</p>
+          <Link
+            href="/onboarding"
+            className="mt-4pxr rounded-button bg-primary px-20pxr py-10pxr text-[14px] font-semibold text-white hover:opacity-80">
+            관심 기업 추가하기
+          </Link>
         </div>
-      </div>
+      )}
+
+      {data && data.length > 0 && (
+        <div className="flex flex-col gap-16pxr lg:flex-row lg:items-start">
+          {/* 메인 콘텐츠 */}
+          <div className="flex flex-1 flex-col gap-14pxr">
+            {hero && <FeedHeroCard item={hero} />}
+            {grid.length > 0 && (
+              <div className="grid grid-cols-2 gap-14pxr sm:grid-cols-3">
+                {grid.map((item) => (
+                  <FeedGridCard key={item.newsId} item={item} />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* 사이드바 */}
+          <div className="flex flex-col gap-16pxr lg:w-80 lg:shrink-0">
+            <AlertBanner
+              title="관심 기업을 더 추가해보세요"
+              description="더 많은 기업을 등록할수록 내 피드가 풍성해져요."
+              buttonLabel="관심 기업 추가하기"
+              buttonHref="/onboarding"
+            />
+          </div>
+        </div>
+      )}
     </main>
   );
 }

--- a/briefin/src/components/feed/FeedGridCard.tsx
+++ b/briefin/src/components/feed/FeedGridCard.tsx
@@ -1,0 +1,50 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import type { FeedItem } from '@/api/feedApi';
+
+export default function FeedGridCard({ item }: { item: FeedItem }) {
+  return (
+    <Link
+      href={`/news/${item.newsId}`}
+      className="group flex flex-col overflow-hidden rounded-card border border-surface-border bg-surface-white transition-shadow hover:shadow-news-hover">
+      {/* 썸네일 */}
+      <div className="relative h-[140px] w-full overflow-hidden bg-surface-muted sm:h-[160px]">
+        {item.thumbnailUrl ? (
+          <Image
+            src={item.thumbnailUrl}
+            alt={item.title}
+            fill
+            className="object-cover transition-transform duration-300 group-hover:scale-105"
+            unoptimized
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center bg-gradient-to-br from-primary-light to-surface-bg">
+            <span className="text-[32px]">📰</span>
+          </div>
+        )}
+        {item.category && (
+          <span className="absolute left-10pxr top-10pxr rounded-badge bg-black/60 px-8pxr py-3pxr text-[11px] font-bold text-white">
+            {item.category}
+          </span>
+        )}
+      </div>
+
+      {/* 텍스트 */}
+      <div className="flex flex-1 flex-col gap-8pxr p-16pxr">
+        <p className="line-clamp-2 text-[14px] font-bold leading-snug text-text-primary transition-colors group-hover:text-primary">
+          {item.title}
+        </p>
+        {(item.relatedCompanies ?? []).length > 0 && (
+          <p className="line-clamp-1 text-[12px] text-primary font-medium">
+            {item.relatedCompanies.join(' · ')}
+          </p>
+        )}
+        <p className="mt-auto text-[11px] text-text-muted">
+          <span className="font-medium text-text-sub">{item.press}</span>
+          <span className="mx-4pxr">·</span>
+          <span>{item.publishedAt}</span>
+        </p>
+      </div>
+    </Link>
+  );
+}

--- a/briefin/src/components/feed/FeedHeroCard.tsx
+++ b/briefin/src/components/feed/FeedHeroCard.tsx
@@ -1,0 +1,50 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import Label from '@/components/common/Label';
+import type { FeedItem } from '@/api/feedApi';
+
+export default function FeedHeroCard({ item }: { item: FeedItem }) {
+  return (
+    <Link
+      href={`/news/${item.newsId}`}
+      className="group relative flex h-[300px] w-full overflow-hidden rounded-card sm:h-[380px]">
+      {/* 배경 썸네일 */}
+      {item.thumbnailUrl ? (
+        <Image
+          src={item.thumbnailUrl}
+          alt={item.title}
+          fill
+          className="object-cover transition-transform duration-500 group-hover:scale-105"
+          unoptimized
+          priority
+        />
+      ) : (
+        <div className="absolute inset-0 bg-gradient-to-br from-primary/80 to-primary-dark/90" />
+      )}
+
+      {/* 어두운 그라데이션 오버레이 */}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
+
+      {/* 콘텐츠 */}
+      <div className="relative mt-auto flex w-full flex-col gap-10pxr p-24pxr sm:p-32pxr">
+        <div className="flex flex-wrap gap-6pxr">
+          {item.category && <Label text={item.category} variant="category" />}
+          {(item.relatedCompanies ?? []).slice(0, 2).map((c) => (
+            <Label key={c} text={c} variant="company" />
+          ))}
+        </div>
+        <h2 className="line-clamp-2 text-[20px] font-bold leading-snug text-white sm:text-[24px]">
+          {item.title}
+        </h2>
+        {item.summary && (
+          <p className="line-clamp-2 text-[13px] text-white/70">{item.summary}</p>
+        )}
+        <p className="text-[12px] text-white/50">
+          <span className="font-medium text-white/70">{item.press}</span>
+          <span className="mx-6pxr">·</span>
+          <span>{item.publishedAt}</span>
+        </p>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
## #️⃣ Issue Number

159

## 📝 변경사항

피드 페이지 UI 변경

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 첫 번째 뉴스를 풀 width 배경 이미지 + 텍스트 오버레이로 크게 표시
- [ ] 나머지 뉴스는 2열/3열로 그리드

### 🖼️ 스크린샷 / 테스트 결과
<img width="996" height="781" alt="image" src="https://github.com/user-attachments/assets/1053ea5c-c15d-4294-97a5-edf56ba4b93d" />

---

## 🛠️ PR 유형

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] 마이페이지 UI 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 뉴스 피드 레이아웃을 단일 목록에서 영웅 카드 + 그리드 형식으로 개편했습니다. 첫 번째 기사는 눈에 띄는 대형 카드로, 나머지는 반응형 그리드로 표시됩니다.
  * 관심 기업이 없을 때 온보딩 페이지로 안내하는 CTA 버튼이 포함된 새로운 빈 상태 메시지를 추가했습니다.
  * 로딩 중 개선된 스켈레톤 UI를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->