### PR TITLE
feat: 마이페이지 UI 개편

### DIFF
--- a/briefin/src/app/(CommonLayout)/mypage/page.tsx
+++ b/briefin/src/app/(CommonLayout)/mypage/page.tsx
@@ -2,7 +2,6 @@
 
 import { Suspense, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import Tabs from '@/components/common/Tabs';
 import MyPageHeader from '@/components/mypage/mypageheader';
 import AccountSection from '@/components/mypage/AccountSection';
 import WatchlistSection from '@/components/mypage/WatchlistSection';
@@ -10,10 +9,41 @@ import SubscribedCompaniesSection from '@/components/mypage/SubscribedCompaniesS
 import MyPageNewsCard from '@/components/mypage/MyPageNewsCard';
 import { MyPageTab } from '@/types/mypage';
 import { TAB_FROM_QUERY, TAB_TO_QUERY, MY_PAGE_TABS } from '@/constants/mypage';
-import { useMyInfo, useScrappedNews, useRecentNews } from '@/hooks/useUser';
+import { useMyInfo, useScrappedNews, useRecentNews, useWatchlist } from '@/hooks/useUser';
 import { useDeleteScrapNews } from '@/hooks/useNews';
 import { useAuthStatus } from '@/providers/AuthSessionProvider';
 import { formatDateTime } from '@/utils/date';
+
+const NAV_ICONS: Record<MyPageTab, React.ReactNode> = {
+  '관심 기업': (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+    </svg>
+  ),
+  '공시 알림 기업': (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+      <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+    </svg>
+  ),
+  '스크랩 뉴스': (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+    </svg>
+  ),
+  '최근 본 뉴스': (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <polyline points="12 6 12 12 16 14" />
+    </svg>
+  ),
+  '계정 관리': (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+      <circle cx="12" cy="7" r="4" />
+    </svg>
+  ),
+};
 
 function MyPageContent() {
   const router = useRouter();
@@ -26,6 +56,7 @@ function MyPageContent() {
   const isAuthenticated = authStatus === 'authenticated';
 
   const { data: userInfo } = useMyInfo();
+  const { data: watchlist } = useWatchlist({ enabled: isAuthenticated });
   const { data: scrapsData, isLoading: scrapsLoading } = useScrappedNews(1, { enabled: isAuthenticated });
   const { data: recentData, isLoading: recentLoading } = useRecentNews(1, { enabled: isAuthenticated });
   const { mutate: deleteScrap } = useDeleteScrapNews();
@@ -35,80 +66,143 @@ function MyPageContent() {
     router.push(`/mypage?tab=${TAB_TO_QUERY[tab]}`);
   };
 
-  const handleLogout = () => {
-    console.log('로그아웃');
-  };
-
   return (
     <div className="min-h-screen bg-surface-bg py-36pxr">
-      <MyPageHeader email={userInfo?.email ?? ''} onLogout={handleLogout} />
-      <Tabs tabs={MY_PAGE_TABS} activeTab={activeTab} onTabChange={handleTabChange} />
+      <div className="lg:flex lg:items-start lg:gap-24pxr">
+        {/* 사이드바 (desktop) */}
+        <div className="lg:w-72 lg:shrink-0">
+          <MyPageHeader
+            email={userInfo?.email ?? ''}
+            watchlistCount={watchlist?.length}
+            scrapCount={scrapsData?.scrapList?.length}
+            recentCount={recentData?.recentList?.length}
+          />
 
-      <div className="pt-28pxr">
-        {activeTab === '관심 기업' && <WatchlistSection />}
-        {activeTab === '공시 알림 기업' && <SubscribedCompaniesSection />}
-        {activeTab === '스크랩 뉴스' && (
-          <div className="flex flex-col gap-12pxr">
-            {scrapsLoading && <p className="py-40pxr text-center text-[14px] text-text-muted">불러오는 중...</p>}
-            {!scrapsLoading && (!scrapsData?.scrapList || scrapsData.scrapList.length === 0) && (
-              <p className="py-40pxr text-center text-[14px] text-text-muted">스크랩한 뉴스가 없습니다.</p>
-            )}
-            {scrapsData?.scrapList?.map((news) => (
-              <MyPageNewsCard
-                key={news.newsId}
-                newsId={news.newsId}
-                title={news.title}
-                summary={news.summary}
-                source={news.source}
-                date={formatDateTime(news.scrapedAt)}
-                thumbnailUrl={news.thumbnailUrl}
-                topLeftSlot={
-                  <button
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      deleteScrap(news.newsId);
-                      setUnscrappedIds((prev) => new Set(prev).add(news.newsId));
-                    }}
-                    aria-label="스크랩 취소"
-                    className="shrink-0 rounded-full pb-6pxr pr-6pxr transition-colors hover:bg-surface-bg">
-                    <svg
-                      width="20"
-                      height="20"
-                      viewBox="0 0 24 24"
-                      fill={unscrappedIds.has(news.newsId) ? 'none' : '#1E3A8A'}
-                      stroke={unscrappedIds.has(news.newsId) ? '#9CA3AF' : '#1E3A8A'}
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round">
-                      <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
-                    </svg>
-                  </button>
-                }
-              />
-            ))}
+          {/* Desktop: 세로 내비 */}
+          <nav className="hidden lg:flex lg:flex-col lg:gap-2pxr">
+            {MY_PAGE_TABS.map((tab) => {
+              const isActive = activeTab === tab;
+              return (
+                <button
+                  key={tab}
+                  type="button"
+                  onClick={() => handleTabChange(tab)}
+                  className={`flex items-center gap-12pxr rounded-xl px-16pxr py-13pxr text-[14px] font-medium transition-colors ${
+                    isActive
+                      ? 'bg-primary text-white'
+                      : 'text-text-secondary hover:bg-surface-muted hover:text-text-primary'
+                  }`}>
+                  <span className={isActive ? 'text-white' : 'text-text-muted'}>
+                    {NAV_ICONS[tab]}
+                  </span>
+                  {tab}
+                </button>
+              );
+            })}
+          </nav>
+        </div>
+
+        {/* 메인 콘텐츠 */}
+        <div className="flex-1 min-w-0">
+          {/* Mobile: 가로 탭 */}
+          <div className="mb-20pxr flex gap-6pxr overflow-x-auto pb-2pxr lg:hidden">
+            {MY_PAGE_TABS.map((tab) => {
+              const isActive = activeTab === tab;
+              return (
+                <button
+                  key={tab}
+                  type="button"
+                  onClick={() => handleTabChange(tab)}
+                  className={`flex shrink-0 items-center gap-6pxr rounded-full px-14pxr py-8pxr text-[13px] font-medium transition-colors ${
+                    isActive
+                      ? 'bg-primary text-white'
+                      : 'border border-surface-border bg-surface-white text-text-secondary hover:bg-surface-muted'
+                  }`}>
+                  {NAV_ICONS[tab]}
+                  {tab}
+                </button>
+              );
+            })}
           </div>
-        )}
-        {activeTab === '최근 본 뉴스' && (
-          <div className="flex flex-col gap-12pxr">
-            {recentLoading && <p className="py-40pxr text-center text-[14px] text-text-muted">불러오는 중...</p>}
-            {!recentLoading && (!recentData?.recentList || recentData.recentList.length === 0) && (
-              <p className="py-40pxr text-center text-[14px] text-text-muted">최근 본 뉴스가 없습니다.</p>
-            )}
-            {recentData?.recentList?.map((news) => (
-              <MyPageNewsCard
-                key={news.newsId}
-                newsId={news.newsId}
-                title={news.title}
-                summary={news.summary}
-                source={news.source}
-                date={formatDateTime(news.viewedAt)}
-                thumbnailUrl={news.thumbnailUrl}
-              />
-            ))}
+
+          {/* 탭 제목 (desktop) */}
+          <div className="mb-16pxr hidden lg:block">
+            <h2 className="fonts-heading3 text-text-primary">{activeTab}</h2>
           </div>
-        )}
-        {activeTab === '계정 관리' && <AccountSection />}
+
+          {activeTab === '관심 기업' && <WatchlistSection />}
+          {activeTab === '공시 알림 기업' && <SubscribedCompaniesSection />}
+          {activeTab === '스크랩 뉴스' && (
+            <div className="flex flex-col gap-12pxr">
+              {scrapsLoading && <p className="py-40pxr text-center text-[14px] text-text-muted">불러오는 중...</p>}
+              {!scrapsLoading && (!scrapsData?.scrapList || scrapsData.scrapList.length === 0) && (
+                <div className="flex flex-col items-center gap-8pxr py-60pxr text-center">
+                  <span className="text-[40px]">🔖</span>
+                  <p className="fonts-body font-medium text-text-primary">스크랩한 뉴스가 없어요</p>
+                  <p className="fonts-label text-text-muted">뉴스를 읽다가 북마크 아이콘을 누르면 여기에 저장돼요.</p>
+                </div>
+              )}
+              {scrapsData?.scrapList?.map((news) => (
+                <MyPageNewsCard
+                  key={news.newsId}
+                  newsId={news.newsId}
+                  title={news.title}
+                  summary={news.summary}
+                  source={news.source}
+                  date={formatDateTime(news.scrapedAt)}
+                  thumbnailUrl={news.thumbnailUrl}
+                  topLeftSlot={
+                    <button
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        deleteScrap(news.newsId);
+                        setUnscrappedIds((prev) => new Set(prev).add(news.newsId));
+                      }}
+                      aria-label="스크랩 취소"
+                      className="shrink-0 rounded-full pb-6pxr pr-6pxr transition-colors hover:bg-surface-bg">
+                      <svg
+                        width="20"
+                        height="20"
+                        viewBox="0 0 24 24"
+                        fill={unscrappedIds.has(news.newsId) ? 'none' : '#1E3A8A'}
+                        stroke={unscrappedIds.has(news.newsId) ? '#9CA3AF' : '#1E3A8A'}
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round">
+                        <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+                      </svg>
+                    </button>
+                  }
+                />
+              ))}
+            </div>
+          )}
+          {activeTab === '최근 본 뉴스' && (
+            <div className="flex flex-col gap-12pxr">
+              {recentLoading && <p className="py-40pxr text-center text-[14px] text-text-muted">불러오는 중...</p>}
+              {!recentLoading && (!recentData?.recentList || recentData.recentList.length === 0) && (
+                <div className="flex flex-col items-center gap-8pxr py-60pxr text-center">
+                  <span className="text-[40px]">📰</span>
+                  <p className="fonts-body font-medium text-text-primary">최근 본 뉴스가 없어요</p>
+                  <p className="fonts-label text-text-muted">뉴스를 읽으면 자동으로 기록돼요.</p>
+                </div>
+              )}
+              {recentData?.recentList?.map((news) => (
+                <MyPageNewsCard
+                  key={news.newsId}
+                  newsId={news.newsId}
+                  title={news.title}
+                  summary={news.summary}
+                  source={news.source}
+                  date={formatDateTime(news.viewedAt)}
+                  thumbnailUrl={news.thumbnailUrl}
+                />
+              ))}
+            </div>
+          )}
+          {activeTab === '계정 관리' && <AccountSection />}
+        </div>
       </div>
     </div>
   );

--- a/briefin/src/components/mypage/SubscribedCompaniesSection.tsx
+++ b/briefin/src/components/mypage/SubscribedCompaniesSection.tsx
@@ -12,20 +12,33 @@ interface SubscribedCompany {
   ticker: string;
 }
 
-function BellUnsubscribeButton({ loading, onClick }: { loading: boolean; onClick: () => void }) {
-  const [hovered, setHovered] = useState(false);
+function TrashButton({ loading, onClick }: { loading: boolean; onClick: () => void }) {
   return (
     <button
       onClick={onClick}
       disabled={loading}
       title="알림 해제"
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      className="flex items-center p-4pxr disabled:opacity-40">
+      aria-label="알림 해제"
+      className="flex items-center p-4pxr text-text-muted transition-colors hover:text-red-500 disabled:opacity-40">
       {loading ? (
         <span className="block h-22pxr w-22pxr animate-pulse rounded-full bg-gray-200" />
       ) : (
-        <img src={hovered ? '/bell-outline-gray.svg' : '/bell-yellow.svg'} alt="" width={22} height={22} />
+        <svg
+          aria-hidden="true"
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round">
+          <polyline points="3 6 5 6 21 6" />
+          <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+          <path d="M10 11v6" />
+          <path d="M14 11v6" />
+          <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+        </svg>
       )}
     </button>
   );
@@ -133,7 +146,7 @@ export default function SubscribedCompaniesSection() {
             <p className="text-[16px] font-bold text-text-primary">{company.name}</p>
           </Link>
           <div className="flex shrink-0 items-center gap-4pxr">
-            <BellUnsubscribeButton
+            <TrashButton
               loading={unsubscribingIds.has(company.companyId)}
               onClick={() => handleUnsubscribe(company.companyId)}
             />

--- a/briefin/src/components/mypage/WatchlistSection.tsx
+++ b/briefin/src/components/mypage/WatchlistSection.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import PushAlarmButton from '@/components/common/PushAlarmButton';
 import { useUnwatchCompany, useWatchlist } from '@/hooks/useUser';
 import type { WatchlistCompany } from '@/types/mypage';
 
@@ -73,7 +72,6 @@ export default function WatchlistSection() {
             <p className="text-[16px] font-bold text-text-primary">{company.companyName ?? company.name}</p>
           </Link>
           <div className="flex shrink-0 items-center gap-4pxr">
-            <PushAlarmButton companyId={company.companyId} />
             <button
               type="button"
               onClick={() => unwatch(company.companyId)}

--- a/briefin/src/components/mypage/mypageheader.tsx
+++ b/briefin/src/components/mypage/mypageheader.tsx
@@ -1,14 +1,52 @@
 interface MyPageHeaderProps {
   email?: string;
-  onLogout?: () => void;
+  watchlistCount?: number;
+  scrapCount?: number;
+  recentCount?: number;
 }
 
-export default function MyPageHeader({ email = 'user@example.com' }: MyPageHeaderProps) {
+export default function MyPageHeader({
+  email = '',
+  watchlistCount,
+  scrapCount,
+  recentCount,
+}: MyPageHeaderProps) {
+  const initial = email ? email[0].toUpperCase() : '?';
+
+  const stats = [
+    { label: '관심 기업', value: watchlistCount },
+    { label: '스크랩', value: scrapCount },
+    { label: '최근 뉴스', value: recentCount },
+  ];
+
   return (
-    <div className="flex items-start justify-between pb-16pxr">
-      <div className="flex flex-col gap-10pxr">
-        <h1 className="fonts-heading3">마이페이지</h1>
+    <div className="mb-24pxr overflow-hidden rounded-2xl bg-gradient-to-br from-primary to-primary-dark p-24pxr sm:p-32pxr">
+      <div className="flex items-center gap-16pxr">
+        {/* 아바타 */}
+        <div className="flex h-56pxr w-56pxr shrink-0 items-center justify-center rounded-full bg-white/20 text-[22px] font-bold text-white">
+          {initial}
+        </div>
+
+        {/* 이메일 */}
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] font-medium uppercase tracking-widest text-white/60">My Account</p>
+          <p className="mt-2pxr truncate text-[15px] font-bold text-white">{email || '로그인 필요'}</p>
+        </div>
       </div>
+
+      {/* 통계 */}
+      {(watchlistCount !== undefined || scrapCount !== undefined || recentCount !== undefined) && (
+        <div className="mt-20pxr flex gap-0 divide-x divide-white/20 rounded-xl bg-white/10 px-4pxr py-12pxr">
+          {stats.map((s) => (
+            <div key={s.label} className="flex flex-1 flex-col items-center gap-2pxr">
+              <span className="text-[18px] font-bold text-white">
+                {s.value ?? '–'}
+              </span>
+              <span className="text-[11px] text-white/60">{s.label}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣ Issue Number

162

## 📝 변경사항

마이페이지 UI 개편

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 좌측 프로필 배너 추가 
- [ ] 우측 각 탭 내용


### 🖼️ 스크린샷 / 테스트 결과

<img width="963" height="569" alt="image" src="https://github.com/user-attachments/assets/1b7b11cc-a43f-495a-8d9b-a1167ccd395c" />


---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 마이페이지 헤더에 관심사/스크랩/최근 본 뉴스 통계 표시 추가

* **리팩토링**
  * 마이페이지 네비게이션 UI 개선 (데스크톱 사이드바, 모바일 탭바)
  * 빈 상태 페이지의 시각화 개선
  * 버튼 UI 단순화 (트래시 아이콘 기반 변경)
  * 헤더 디자인 새로 정의 (아바타 초기문자 및 이메일 표시)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->