### PR TITLE
feat: 기업 히스토리 타임라인 UI 개선

### DIFF
--- a/briefin/src/app/(CommonLayout)/companies/[id]/page.tsx
+++ b/briefin/src/app/(CommonLayout)/companies/[id]/page.tsx
@@ -281,7 +281,7 @@ export default function CompanyDetailPage() {
             buttonLabel={isSubscribed ? '알림 해제하기' : '알림 설정하기'}
             onButtonClick={handleAlertClick}
           />
-          <NewsTimeline items={timeline} loading={timelineLoading} />
+          <NewsTimeline items={timeline} loading={timelineLoading} title="기업 히스토리" />
         </div>
       </div>
     </div>

--- a/briefin/src/components/common/NewsTimeline.tsx
+++ b/briefin/src/components/common/NewsTimeline.tsx
@@ -1,68 +1,94 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { NewsTimelineProps } from '@/types/timeline';
 
-export default function NewsTimeline({ items, loading }: NewsTimelineProps) {
+const PAGE_SIZE = 10;
+
+export default function NewsTimeline({ items, loading, title = '뉴스 히스토리' }: NewsTimelineProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const sorted = [...items].sort((a, b) => {
+    const ka = a.publishedAt ?? a.date ?? '';
+    const kb = b.publishedAt ?? b.date ?? '';
+    return kb.localeCompare(ka);
+  });
+
+  const visible = expanded ? sorted : sorted.slice(0, PAGE_SIZE);
+  const hasMore = sorted.length > PAGE_SIZE;
+
   return (
     <div className="rounded-card border border-[#E5E7EB] bg-surface-white">
       {/* Header */}
       <div className="px-20pxr pt-16pxr">
-        <p className="text-[15px] font-bold text-text-primary">뉴스 히스토리</p>
+        <p className="text-[15px] font-bold text-text-primary">{title}</p>
       </div>
 
       {/* Timeline */}
-      <div className="border-t border-[#E5E7EB] mt-12pxr px-20pxr py-16pxr">
+      <div className="mt-12pxr border-t border-[#E5E7EB] px-20pxr py-16pxr">
         {loading ? (
           <TimelineSkeleton />
-        ) : items.length === 0 ? (
+        ) : sorted.length === 0 ? (
           <p className="py-12pxr text-center text-[12px] text-text-muted">관련 뉴스가 없습니다.</p>
         ) : (
-          <div className="flex flex-col">
-            {items.map((item, idx) => {
-              const isLast = idx === items.length - 1;
-              const rowKey = item.newsId ?? `${item.date}-${idx}`;
+          <>
+            <div className="flex flex-col">
+              {visible.map((item, idx) => {
+                const isFirst = idx === 0;
+                const isLast = idx === visible.length - 1 && !hasMore;
+                const rowKey = item.newsId ?? `${item.date}-${idx}`;
 
-              const inner = (
-                <div className="flex items-start">
-                  {/* Date */}
-                  <div className="w-70pxr shrink-0 pr-12pxr pt-3pxr text-right">
-                    <span className="text-[11px] font-medium text-text-muted">{item.date}</span>
+                const inner = (
+                  <div className="flex items-start">
+                    {/* Date */}
+                    <div className="w-70pxr shrink-0 pr-12pxr pt-3pxr text-right">
+                      <span className="text-[11px] font-medium text-text-muted">{item.date}</span>
+                    </div>
+
+                    {/* Dot + line */}
+                    <div className="flex shrink-0 flex-col items-center" style={{ width: 14 }}>
+                      <div
+                        className={[
+                          'mt-5pxr rounded-full',
+                          isFirst ? 'h-8pxr w-8pxr bg-primary' : 'h-6pxr w-6pxr bg-[#D1D5DB]',
+                        ].join(' ')}
+                      />
+                      {!isLast && <div className="mt-4pxr w-[1.5px] flex-1 bg-[#E5E7EB]" style={{ minHeight: 28 }} />}
+                    </div>
+
+                    {/* Content */}
+                    <div className={['flex flex-1 flex-col gap-4pxr pl-10pxr', isLast ? '' : 'pb-16pxr'].join(' ')}>
+                      {isFirst && (
+                        <span className="inline-block self-start rounded-badge bg-primary px-7pxr py-2pxr text-[10px] font-bold text-white">
+                          최신
+                        </span>
+                      )}
+                      <p className="leading-18pxr text-[12px] font-bold text-primary">{item.title}</p>
+                      <p className="text-[10px] font-medium text-text-muted">{item.source}</p>
+                    </div>
                   </div>
+                );
 
-                  {/* Dot + line */}
-                  <div className="flex shrink-0 flex-col items-center" style={{ width: 14 }}>
-                    <div
-                      className={[
-                        'mt-5pxr rounded-full',
-                        item.isLatest ? 'h-8pxr w-8pxr bg-primary' : 'h-6pxr w-6pxr bg-[#D1D5DB]',
-                      ].join(' ')}
-                    />
-                    {!isLast && <div className="mt-4pxr w-[1.5px] flex-1 bg-[#E5E7EB]" style={{ minHeight: 28 }} />}
-                  </div>
+                return item.newsId ? (
+                  <Link key={rowKey} href={`/news/${item.newsId}`} className="group">
+                    {inner}
+                  </Link>
+                ) : (
+                  <div key={rowKey}>{inner}</div>
+                );
+              })}
+            </div>
 
-                  {/* Content */}
-                  <div className={['flex flex-1 flex-col gap-4pxr pl-10pxr', isLast ? '' : 'pb-16pxr'].join(' ')}>
-                    {item.isLatest && (
-                      <span className="inline-block self-start rounded-badge bg-primary px-7pxr py-2pxr text-[10px] font-bold text-white">
-                        최신
-                      </span>
-                    )}
-                    <p className="leading-18pxr text-[12px] font-bold text-primary">{item.title}</p>
-                    <p className="text-[10px] font-medium text-text-muted">{item.source}</p>
-                  </div>
-                </div>
-              );
-
-              return item.newsId ? (
-                <Link key={rowKey} href={`/news/${item.newsId}`} className="group">
-                  {inner}
-                </Link>
-              ) : (
-                <div key={rowKey}>{inner}</div>
-              );
-            })}
-          </div>
+            {hasMore && (
+              <button
+                type="button"
+                onClick={() => setExpanded((v) => !v)}
+                className="mt-8pxr w-full rounded-lg py-8pxr text-[12px] font-medium text-text-muted transition-colors hover:bg-surface-muted hover:text-text-primary">
+                {expanded ? '접기' : `더보기 (${sorted.length - PAGE_SIZE}개)`}
+              </button>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/briefin/src/types/timeline.ts
+++ b/briefin/src/types/timeline.ts
@@ -12,4 +12,5 @@ export interface NewsTimelineItem {
 export interface NewsTimelineProps {
   items: NewsTimelineItem[];
   loading?: boolean;
+  title?: string;
 }


### PR DESCRIPTION
## #️⃣ Issue Number

165

## 📝 변경사항

기업 상세 타임라인 컴포넌트 변경

### 🎯 핵심 변경 사항 (Key Changes)

- [x] 뉴스 히스토리 -> 기업 히스토리
- [x] 최신순 정렬
- [x] 10개 초과 시 더보기 버튼 표시


### 🖼️ 스크린샷 / 테스트 결과

<img width="435" height="864" alt="image" src="https://github.com/user-attachments/assets/6045e2a0-810e-441c-8f12-03d0f30f7f27" />

---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 타임라인에 "더보기/접기" 토글 버튼 추가 - 10개 이상의 항목이 있을 때 확장/축소 가능
  * 타임라인 섹션의 제목을 커스터마이징할 수 있도록 개선
  * 타임라인 항목을 발행 날짜 기준으로 정렬하여 최신 소식 우선 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->