### PR TITLE
feat: 관심기업 마이페이지 동기화

### DIFF
--- a/briefin/src/app/(CommonLayout)/companies/page.tsx
+++ b/briefin/src/app/(CommonLayout)/companies/page.tsx
@@ -4,8 +4,8 @@ import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import CompanySearchInput from '@/components/companies/CompanySearchInput';
-import { apiClient } from '@/api/client';
 import { useAuthStatus } from '@/providers/AuthSessionProvider';
+import { useWatchCompany, useUnwatchCompany } from '@/hooks/useUser';
 
 interface PopularCompany {
   id: number;
@@ -40,23 +40,17 @@ const VISIBLE_ROWS = 6.5;
 function StarButton({ companyId, initialWatchlisted }: { companyId: number; initialWatchlisted: boolean }) {
   const authStatus = useAuthStatus();
   const [watchlisted, setWatchlisted] = useState(initialWatchlisted);
-  const [loading, setLoading] = useState(false);
+  const { mutate: doWatch, isPending: watching } = useWatchCompany();
+  const { mutate: doUnwatch, isPending: unwatching } = useUnwatchCompany();
+  const loading = watching || unwatching;
 
-  const handleClick = async (e: React.MouseEvent) => {
+  const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (authStatus !== 'authenticated' || loading) return;
-    setLoading(true);
-    try {
-      if (watchlisted) {
-        await apiClient.delete(`/api/users/${companyId}/watch`);
-      } else {
-        await apiClient.post(`/api/users/${companyId}/watch`);
-      }
-      setWatchlisted(prev => !prev);
-    } catch {
-      alert('요청에 실패했어요. 다시 시도해 주세요.');
-    } finally {
-      setLoading(false);
+    if (watchlisted) {
+      doUnwatch(companyId, { onSuccess: () => setWatchlisted(false), onError: () => alert('요청에 실패했어요. 다시 시도해 주세요.') });
+    } else {
+      doWatch(companyId, { onSuccess: () => setWatchlisted(true), onError: () => alert('요청에 실패했어요. 다시 시도해 주세요.') });
     }
   };
 


### PR DESCRIPTION
## #️⃣ Issue Number

172

## 📝 변경사항

기업 페이지에서 관심기업 설정 시 마이페이지에서 관심기업 리스트 동기화

### 🎯 핵심 변경 사항 (Key Changes)

- [x] 관심기업 추가/해제 로직을 직접 API 호출 방식에서 `useWatchCompany`, `useUnwatchCompany` mutation 훅 사용 방식으로 변경
- [x] 로컬 `loading` 상태를 제거하고 mutation의 `isPending` 상태로 로딩 처리 일원화
- [x] 관심기업 추가/해제 성공 시 로컬 watchlisted 상태를 즉시 갱신하도록 수정
- [x] 요청 실패 시 공통 에러 처리(alert)가 동작하도록 정리

---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [x] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] 마이페이지 프로필 배너 위치 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **성능 및 안정성 개선**
  * 회사 관심 목록 추가/제거 기능의 내부 구조를 개선하여 더욱 안정적인 동작을 보장합니다. 오류 처리가 강화되어 사용자 경험이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->