### PR TITLE
fix: 마이페이지 프로필 배너 위치 좌측으로 변경

### DIFF
--- a/briefin/src/app/(CommonLayout)/mypage/page.tsx
+++ b/briefin/src/app/(CommonLayout)/mypage/page.tsx
@@ -3,7 +3,6 @@
 import { Suspense, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import MyPageHeader from '@/components/mypage/mypageheader';
-import Tabs from '@/components/common/Tabs';
 import AccountSection from '@/components/mypage/AccountSection';
 import WatchlistSection from '@/components/mypage/WatchlistSection';
 import SubscribedCompaniesSection from '@/components/mypage/SubscribedCompaniesSection';
@@ -22,6 +21,13 @@ const NAV_ICONS: Record<MyPageTab, React.ReactNode> = {
   '스크랩 뉴스': <ScrapIcon />,
   '최근 본 뉴스': <RecentIcon />,
   '계정 관리': <AccountIcon />,
+};
+
+const MOBILE_ICONS: Partial<Record<MyPageTab, React.ReactNode>> = {
+  '관심 기업': <WatchlistIcon size={13} fill="currentColor" strokeWidth="1.5" />,
+  '공시 알림 기업': <AlertIcon size={13} strokeWidth="2.2" />,
+  '스크랩 뉴스': <ScrapIcon size={13} />,
+  '최근 본 뉴스': <RecentIcon size={13} />,
 };
 
 function MyPageContent() {
@@ -49,101 +55,157 @@ function MyPageContent() {
     console.log('로그아웃');
   };
 
-  const tabIcons: Partial<Record<MyPageTab, React.ReactNode>> = {
-    '관심 기업': <WatchlistIcon size={13} fill="currentColor" strokeWidth="1.5" />,
-    '공시 알림 기업': <AlertIcon size={13} strokeWidth="2.2" />,
-    '스크랩 뉴스': <ScrapIcon size={13} />,
-    '최근 본 뉴스': <RecentIcon size={13} />,
-  };
-
   return (
     <div className="min-h-screen bg-surface-bg py-36pxr">
-      <MyPageHeader
-        email={userInfo?.email ?? ''}
-        onLogout={handleLogout}
-        watchlistCount={watchlist?.length}
-        scrapCount={scrapsData?.totalCount}
-        recentCount={recentData?.totalCount}
-      />
-      <Tabs tabs={MY_PAGE_TABS} activeTab={activeTab} onTabChange={handleTabChange} tabIcons={tabIcons} />
+      {/* 모바일: 배너 상단 */}
+      <div className="mb-20pxr lg:hidden">
+        <MyPageHeader
+          email={userInfo?.email ?? ''}
+          onLogout={handleLogout}
+          watchlistCount={watchlist?.length}
+          scrapCount={scrapsData?.totalCount}
+          recentCount={recentData?.totalCount}
+        />
+      </div>
 
-      <div className="pt-28pxr">
-        {activeTab === '관심 기업' && <WatchlistSection />}
-        {activeTab === '공시 알림 기업' && <SubscribedCompaniesSection />}
-        {activeTab === '스크랩 뉴스' && (
-          <div className="flex flex-col gap-12pxr">
-            {scrapsLoading && <p className="py-40pxr text-center text-[14px] text-text-muted">불러오는 중...</p>}
-            {!scrapsLoading && (!scrapsData?.scrapList || scrapsData.scrapList.length === 0) && (
-              <div className="flex flex-col items-center gap-12pxr py-60pxr text-center">
-                <div className="flex h-[52px] w-[52px] items-center justify-center rounded-full bg-[#E5E7EB]">
-                  <ScrapIcon size={22} stroke="#9CA3AF" />
-                </div>
-                <p className="fonts-body font-medium text-text-primary">스크랩한 뉴스가 없어요</p>
-                <p className="fonts-label text-text-muted">뉴스를 읽다가 북마크 아이콘을 누르면 여기에 저장돼요.</p>
-              </div>
-            )}
-            {scrapsData?.scrapList?.map((news) => (
-              <MyPageNewsCard
-                key={news.newsId}
-                newsId={news.newsId}
-                title={news.title}
-                summary={news.summary}
-                source={news.source}
-                date={formatDateTime(news.scrapedAt)}
-                thumbnailUrl={news.thumbnailUrl}
-                topLeftSlot={
-                  <button
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      deleteScrap(news.newsId);
-                      setUnscrappedIds((prev) => new Set(prev).add(news.newsId));
-                    }}
-                    aria-label="스크랩 취소"
-                    className="shrink-0 rounded-full pb-6pxr pr-6pxr transition-colors hover:bg-surface-bg">
-                    <svg
-                      width="20"
-                      height="20"
-                      viewBox="0 0 24 24"
-                      fill={unscrappedIds.has(news.newsId) ? 'none' : '#1E3A8A'}
-                      stroke={unscrappedIds.has(news.newsId) ? '#9CA3AF' : '#1E3A8A'}
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round">
-                      <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
-                    </svg>
-                  </button>
-                }
-              />
-            ))}
+      <div className="lg:flex lg:items-start lg:gap-24pxr">
+        {/* 데스크탑: 좌측 사이드바 */}
+        <div className="hidden lg:flex lg:w-72 lg:shrink-0 lg:flex-col lg:gap-8pxr">
+          <MyPageHeader
+            email={userInfo?.email ?? ''}
+            onLogout={handleLogout}
+            watchlistCount={watchlist?.length}
+            scrapCount={scrapsData?.totalCount}
+            recentCount={recentData?.totalCount}
+          />
+          <nav className="flex flex-col gap-2pxr">
+            {MY_PAGE_TABS.map((tab) => {
+              const isActive = activeTab === tab;
+              return (
+                <button
+                  key={tab}
+                  type="button"
+                  onClick={() => handleTabChange(tab)}
+                  className={`flex items-center gap-12pxr rounded-xl px-16pxr py-13pxr text-[14px] font-medium transition-colors ${
+                    isActive
+                      ? 'bg-primary text-white'
+                      : 'text-text-secondary hover:bg-surface-muted hover:text-text-primary'
+                  }`}>
+                  <span className={isActive ? 'text-white' : 'text-text-muted'}>
+                    {NAV_ICONS[tab]}
+                  </span>
+                  {tab}
+                </button>
+              );
+            })}
+          </nav>
+        </div>
+
+        {/* 메인 콘텐츠 */}
+        <div className="flex-1 min-w-0">
+          {/* 모바일: 가로 탭 */}
+          <div className="mb-20pxr flex gap-6pxr overflow-x-auto pb-2pxr lg:hidden">
+            {MY_PAGE_TABS.map((tab) => {
+              const isActive = activeTab === tab;
+              return (
+                <button
+                  key={tab}
+                  type="button"
+                  onClick={() => handleTabChange(tab)}
+                  className={`flex shrink-0 items-center gap-6pxr rounded-full px-14pxr py-8pxr text-[13px] font-medium transition-colors ${
+                    isActive
+                      ? 'bg-primary text-white'
+                      : 'border border-surface-border bg-surface-white text-text-secondary hover:bg-surface-muted'
+                  }`}>
+                  {MOBILE_ICONS[tab]}
+                  {tab}
+                </button>
+              );
+            })}
           </div>
-        )}
-        {activeTab === '최근 본 뉴스' && (
-          <div className="flex flex-col gap-12pxr">
-            {recentLoading && <p className="py-40pxr text-center text-[14px] text-text-muted">불러오는 중...</p>}
-            {!recentLoading && (!recentData?.recentList || recentData.recentList.length === 0) && (
-              <div className="flex flex-col items-center gap-12pxr py-60pxr text-center">
-                <div className="flex h-[52px] w-[52px] items-center justify-center rounded-full bg-[#E5E7EB]">
-                  <RecentIcon size={22} stroke="#9CA3AF" />
-                </div>
-                <p className="fonts-body font-medium text-text-primary">최근 본 뉴스가 없어요</p>
-                <p className="fonts-label text-text-muted">뉴스를 읽으면 자동으로 여기에 기록돼요.</p>
-              </div>
-            )}
-            {recentData?.recentList?.map((news) => (
-              <MyPageNewsCard
-                key={news.newsId}
-                newsId={news.newsId}
-                title={news.title}
-                summary={news.summary}
-                source={news.source}
-                date={formatDateTime(news.viewedAt)}
-                thumbnailUrl={news.thumbnailUrl}
-              />
-            ))}
+
+          {/* 데스크탑: 탭 제목 */}
+          <div className="mb-16pxr hidden lg:block">
+            <h2 className="fonts-heading3 text-text-primary">{activeTab}</h2>
           </div>
-        )}
-        {activeTab === '계정 관리' && <AccountSection />}
+
+          {activeTab === '관심 기업' && <WatchlistSection />}
+          {activeTab === '공시 알림 기업' && <SubscribedCompaniesSection />}
+          {activeTab === '스크랩 뉴스' && (
+            <div className="flex flex-col gap-12pxr">
+              {scrapsLoading && <p className="py-40pxr text-center text-[14px] text-text-muted">불러오는 중...</p>}
+              {!scrapsLoading && (!scrapsData?.scrapList || scrapsData.scrapList.length === 0) && (
+                <div className="flex flex-col items-center gap-12pxr py-60pxr text-center">
+                  <div className="flex h-13 w-13 items-center justify-center rounded-full bg-[#E5E7EB]">
+                    <ScrapIcon size={22} stroke="#9CA3AF" />
+                  </div>
+                  <p className="fonts-body font-medium text-text-primary">스크랩한 뉴스가 없어요</p>
+                  <p className="fonts-label text-text-muted">뉴스를 읽다가 북마크 아이콘을 누르면 여기에 저장돼요.</p>
+                </div>
+              )}
+              {scrapsData?.scrapList?.map((news) => (
+                <MyPageNewsCard
+                  key={news.newsId}
+                  newsId={news.newsId}
+                  title={news.title}
+                  summary={news.summary}
+                  source={news.source}
+                  date={formatDateTime(news.scrapedAt)}
+                  thumbnailUrl={news.thumbnailUrl}
+                  topLeftSlot={
+                    <button
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        deleteScrap(news.newsId);
+                        setUnscrappedIds((prev) => new Set(prev).add(news.newsId));
+                      }}
+                      aria-label="스크랩 취소"
+                      className="shrink-0 rounded-full pb-6pxr pr-6pxr transition-colors hover:bg-surface-bg">
+                      <svg
+                        width="20"
+                        height="20"
+                        viewBox="0 0 24 24"
+                        fill={unscrappedIds.has(news.newsId) ? 'none' : '#1E3A8A'}
+                        stroke={unscrappedIds.has(news.newsId) ? '#9CA3AF' : '#1E3A8A'}
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round">
+                        <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+                      </svg>
+                    </button>
+                  }
+                />
+              ))}
+            </div>
+          )}
+          {activeTab === '최근 본 뉴스' && (
+            <div className="flex flex-col gap-12pxr">
+              {recentLoading && <p className="py-40pxr text-center text-[14px] text-text-muted">불러오는 중...</p>}
+              {!recentLoading && (!recentData?.recentList || recentData.recentList.length === 0) && (
+                <div className="flex flex-col items-center gap-12pxr py-60pxr text-center">
+                  <div className="flex h-13 w-13 items-center justify-center rounded-full bg-[#E5E7EB]">
+                    <RecentIcon size={22} stroke="#9CA3AF" />
+                  </div>
+                  <p className="fonts-body font-medium text-text-primary">최근 본 뉴스가 없어요</p>
+                  <p className="fonts-label text-text-muted">뉴스를 읽으면 자동으로 여기에 기록돼요.</p>
+                </div>
+              )}
+              {recentData?.recentList?.map((news) => (
+                <MyPageNewsCard
+                  key={news.newsId}
+                  newsId={news.newsId}
+                  title={news.title}
+                  summary={news.summary}
+                  source={news.source}
+                  date={formatDateTime(news.viewedAt)}
+                  thumbnailUrl={news.thumbnailUrl}
+                />
+              ))}
+            </div>
+          )}
+          {activeTab === '계정 관리' && <AccountSection />}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## #️⃣ Issue Number

174

## 📝 변경사항

마이페이지 프로필 배너를 상단에서 좌측으로 이동하여 레이아웃을 개선했다.

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 프로필 배너 위치 변경 (상단 → 좌측)
- [ ] 레이아웃 구조 및 스타일 수정

### 🖼️ 스크린샷 / 테스트 결과

<img width="879" height="620" alt="image" src="https://github.com/user-attachments/assets/1c08dced-5158-404e-9ce9-1c55509bb943" />

---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] 마이페이지 프로필 배너 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 마이페이지 레이아웃 개선

* **스타일**
  * 마이페이지 레이아웃을 모바일과 데스크톱 환경에 최적화하여 개선
  * 모바일에서는 가로 스크롤 가능한 탭 네비게이션과 상단 헤더 제공
  * 데스크톱에서는 왼쪽 사이드바 구조로 변경되어 더 효율적인 콘텐츠 탐색 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->