### PR TITLE
feat: 마이페이지 배너 구성 변경

### DIFF
--- a/briefin/src/app/(CommonLayout)/companies/[id]/page.tsx
+++ b/briefin/src/app/(CommonLayout)/companies/[id]/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
+import { SUBSCRIBED_COMPANIES_KEY } from '@/components/mypage/SubscribedCompaniesSection';
 import Tabs from '@/components/common/Tabs';
 import CompanyHero from '@/components/companies/CompanyHero';
 import NewsCard from '@/components/news/NewsCard';
@@ -24,6 +26,7 @@ import { useWatchlist, useWatchCompany, useUnwatchCompany } from '@/hooks/useUse
 
 export default function CompanyDetailPage() {
   const { id } = useParams();
+  const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState<CompanyDetailTab>('관련 뉴스');
   const [company, setCompany] = useState<CompanyDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -181,6 +184,7 @@ export default function CompanyDetailPage() {
         const success = await subscribePush(company.id);
         if (success) setIsSubscribed(true);
       }
+      queryClient.invalidateQueries({ queryKey: SUBSCRIBED_COMPANIES_KEY });
     } catch (error) {
       console.error('알림 설정 실패:', error);
       alert('알림 설정에 실패했습니다.');

--- a/briefin/src/app/(CommonLayout)/mypage/page.tsx
+++ b/briefin/src/app/(CommonLayout)/mypage/page.tsx
@@ -12,6 +12,9 @@ import { TAB_FROM_QUERY, TAB_TO_QUERY, MY_PAGE_TABS } from '@/constants/mypage';
 import { WatchlistIcon, AlertIcon, ScrapIcon, RecentIcon, AccountIcon } from '@/constants/mypageIcons';
 import { useMyInfo, useScrappedNews, useRecentNews, useWatchlist } from '@/hooks/useUser';
 import { useDeleteScrapNews } from '@/hooks/useNews';
+import { useQuery } from '@tanstack/react-query';
+import { fetchSubscribedCompanies } from '@/api/disclosureApi';
+import { SUBSCRIBED_COMPANIES_KEY } from '@/components/mypage/SubscribedCompaniesSection';
 import { useAuthStatus } from '@/providers/AuthSessionProvider';
 import { formatDateTime } from '@/utils/date';
 
@@ -44,6 +47,11 @@ function MyPageContent() {
   const { data: watchlist } = useWatchlist({ enabled: isAuthenticated });
   const { data: scrapsData, isLoading: scrapsLoading } = useScrappedNews(1, { enabled: isAuthenticated });
   const { data: recentData, isLoading: recentLoading } = useRecentNews(1, { enabled: isAuthenticated });
+  const { data: subscribedCompanies } = useQuery({
+    queryKey: SUBSCRIBED_COMPANIES_KEY,
+    queryFn: fetchSubscribedCompanies,
+    enabled: isAuthenticated,
+  });
   const { mutate: deleteScrap } = useDeleteScrapNews();
   const [unscrappedIds, setUnscrappedIds] = useState<Set<number>>(new Set());
 
@@ -63,8 +71,8 @@ function MyPageContent() {
           email={userInfo?.email ?? ''}
           onLogout={handleLogout}
           watchlistCount={watchlist?.length}
+          alertCount={subscribedCompanies?.length}
           scrapCount={scrapsData?.totalCount}
-          recentCount={recentData?.totalCount}
         />
       </div>
 
@@ -75,8 +83,8 @@ function MyPageContent() {
             email={userInfo?.email ?? ''}
             onLogout={handleLogout}
             watchlistCount={watchlist?.length}
+            alertCount={subscribedCompanies?.length}
             scrapCount={scrapsData?.totalCount}
-            recentCount={recentData?.totalCount}
           />
           <nav className="flex flex-col gap-2pxr">
             {MY_PAGE_TABS.map((tab) => {

--- a/briefin/src/components/mypage/SubscribedCompaniesSection.tsx
+++ b/briefin/src/components/mypage/SubscribedCompaniesSection.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchSubscribedCompanies } from '@/api/disclosureApi';
 import { AlertIcon } from '@/constants/mypageIcons';
 import { unsubscribePush } from '@/lib/pushNotification';
+
+export const SUBSCRIBED_COMPANIES_KEY = ['subscribed-companies'];
 
 interface SubscribedCompany {
   companyId: number;
@@ -69,29 +72,22 @@ function CompanyLogo({ company }: { company: SubscribedCompany }) {
 }
 
 export default function SubscribedCompaniesSection() {
-  const [companies, setCompanies] = useState<SubscribedCompany[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [hasError, setHasError] = useState(false);
+  const queryClient = useQueryClient();
   const [unsubscribingIds, setUnsubscribingIds] = useState<Set<number>>(new Set());
 
-  useEffect(() => {
-    fetchSubscribedCompanies()
-      .then((data) => {
-        setCompanies(data ?? []);
-        setHasError(false);
-      })
-      .catch(() => {
-        setHasError(true);
-        setCompanies([]);
-      })
-      .finally(() => setLoading(false));
-  }, []);
+  const { data: companies, isLoading, isError } = useQuery({
+    queryKey: SUBSCRIBED_COMPANIES_KEY,
+    queryFn: fetchSubscribedCompanies,
+  });
 
   const handleUnsubscribe = async (companyId: number) => {
     setUnsubscribingIds((prev) => new Set(prev).add(companyId));
     try {
       await unsubscribePush(companyId);
-      setCompanies((prev) => prev.filter((c) => c.companyId !== companyId));
+      queryClient.setQueryData<SubscribedCompany[]>(
+        SUBSCRIBED_COMPANIES_KEY,
+        (prev) => (prev ?? []).filter((c) => c.companyId !== companyId),
+      );
     } catch {
       alert('알림 해제에 실패했습니다.');
     } finally {
@@ -103,7 +99,7 @@ export default function SubscribedCompaniesSection() {
     }
   };
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="flex animate-pulse flex-col gap-12pxr">
         {[1, 2, 3].map((i) => (
@@ -122,7 +118,7 @@ export default function SubscribedCompaniesSection() {
     );
   }
 
-  if (hasError) {
+  if (isError) {
     return (
       <p className="py-40pxr text-center text-[14px] text-text-muted">
         목록을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
@@ -130,10 +126,10 @@ export default function SubscribedCompaniesSection() {
     );
   }
 
-  if (companies.length === 0) {
+  if (!companies || companies.length === 0) {
     return (
       <div className="flex flex-col items-center gap-12pxr py-60pxr text-center">
-        <div className="flex h-[52px] w-[52px] items-center justify-center rounded-full bg-[#E5E7EB]">
+        <div className="flex h-13 w-13 items-center justify-center rounded-full bg-[#E5E7EB]">
           <AlertIcon size={22} stroke="#9CA3AF" strokeWidth="2.2" />
         </div>
         <p className="fonts-body font-medium text-text-primary">공시 알림 신청한 기업이 없어요</p>

--- a/briefin/src/components/mypage/mypageheader.tsx
+++ b/briefin/src/components/mypage/mypageheader.tsx
@@ -1,24 +1,24 @@
 interface MyPageHeaderProps {
   email?: string;
   watchlistCount?: number;
+  alertCount?: number;
   scrapCount?: number;
-  recentCount?: number;
   onLogout?: () => void;
 }
 
 export default function MyPageHeader({
   email = '',
   watchlistCount,
+  alertCount,
   scrapCount,
-  recentCount,
   onLogout,
 }: MyPageHeaderProps) {
   const initial = email ? email[0].toUpperCase() : '?';
 
   const stats = [
     { label: '관심 기업', value: watchlistCount },
+    { label: '공시 알림', value: alertCount },
     { label: '스크랩', value: scrapCount },
-    { label: '최근 뉴스', value: recentCount },
   ];
 
   return (
@@ -46,7 +46,7 @@ export default function MyPageHeader({
       </div>
 
       {/* 통계 */}
-      {(watchlistCount !== undefined || scrapCount !== undefined || recentCount !== undefined) && (
+      {(watchlistCount !== undefined || alertCount !== undefined || scrapCount !== undefined) && (
         <div className="mt-20pxr flex gap-0 divide-x divide-white/20 rounded-xl bg-white/10 px-4pxr py-12pxr">
           {stats.map((s) => (
             <div key={s.label} className="flex flex-1 flex-col items-center gap-2pxr">


### PR DESCRIPTION
## #️⃣ Issue Number

176
## 📝 변경사항

마이페이지 프로필 배너의 정보와 순서를 탭 구조에 맞게 수정했다.

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 공시 알림 기업 개수 추가 및 기존 최근 뉴스 항목 제거
- [ ] 항목 순서 변경 (관심기업 → 공시 알림 기업 → 스크랩 뉴스)

## 🛠️ PR 유형

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] 공시 이후 라우팅 수정
