### PR TITLE
feat: 공시 알림 리다이렉트 변경

### DIFF
--- a/briefin/src/components/disclosure/DisclosureSideBar.tsx
+++ b/briefin/src/components/disclosure/DisclosureSideBar.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import AlertBanner from '@/components/common/AlertBanner';
 import { DisclosureSidebarProps } from '@/types/disclosure';
 import { getCategoryLabel } from '@/constants/disclosureCategories';
@@ -16,6 +17,7 @@ export default function DisclosureSidebar({
   const [isSubscribed, setIsSubscribed] = useState(false);
   const [loading, setLoading] = useState(true);
   const authVersion = useAuthSessionVersion();
+  const router = useRouter();
 
   // auth 초기화 완료 후 구독 상태 조회 (authVersion === 0이면 토큰 미설정 상태)
   useEffect(() => {
@@ -57,7 +59,10 @@ export default function DisclosureSidebar({
         setIsSubscribed(false);
       } else {
         const success = await subscribePush(companyId);
-        if (success) setIsSubscribed(true);
+        if (success) {
+          setIsSubscribed(true);
+          if (companyId) router.push(`/companies/${companyId}`);
+        }
       }
     } catch (error) {
       console.error('알림 설정 실패:', error);

--- a/briefin/src/lib/pushNotification.ts
+++ b/briefin/src/lib/pushNotification.ts
@@ -18,7 +18,8 @@ export async function subscribePush(companyId: number): Promise<boolean> {
     return false;
   }
 
-  const registration = await navigator.serviceWorker.register('/sw.js');
+  const existing = await navigator.serviceWorker.getRegistration('/sw.js');
+  const registration = existing ?? await navigator.serviceWorker.register('/sw.js');
   await navigator.serviceWorker.ready;
 
   const vapidPublicKey = await fetchVapidPublicKey();


### PR DESCRIPTION
## #️⃣ Issue Number

178

## 📝 변경사항

공시 페이지에서 "공시 알림 받기" 버튼 클릭 시 이동 경로를 마이페이지에서 기업페이지로 변경했다.

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 버튼 클릭 시 라우팅 경로 변경 (마이페이지 → 기업페이지)

---

## 🛠️ PR 유형

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] 홈화면 관심 기업 컴포넌트에서 관심 기업이 없을 경우 멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 푸시 알림 구독 완료 시 해당 회사의 페이지로 자동으로 이동합니다.

* **성능 개선**
  * 푸시 알림 설정 중 서비스 워커 처리 방식을 최적화하여 더욱 효율적인 성능을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->