### PR TITLE
fix: 관심 기업 없을 때 UI 통일

### DIFF
--- a/briefin/src/components/home/HomeWatchlistSection.tsx
+++ b/briefin/src/components/home/HomeWatchlistSection.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { useWatchlist } from '@/hooks/useUser';
 import { useAuthStatus } from '@/providers/AuthSessionProvider';
+import { WatchlistIcon } from '@/constants/mypageIcons';
 import type { WatchlistCompany } from '@/types/mypage';
 
 function CompanyLogo({ company }: { company: WatchlistCompany }) {
@@ -71,7 +72,13 @@ export default function HomeWatchlistSection() {
       )}
 
       {status === 'authenticated' && !isLoading && (!watchlist || watchlist.length === 0) && (
-        <p className="py-20pxr text-center text-[13px] text-text-muted">등록된 관심 기업이 없습니다.</p>
+        <div className="flex flex-col items-center gap-8pxr py-24pxr text-center">
+          <div className="flex h-13 w-13 items-center justify-center rounded-full bg-[#E5E7EB]">
+            <WatchlistIcon size={22} stroke="#9CA3AF" />
+          </div>
+          <p className="text-[13px] font-medium text-text-primary">관심 기업이 없어요</p>
+          <p className="text-[12px] text-text-muted">기업 페이지에서 하트 아이콘을 누르면 여기에 저장돼요.</p>
+        </div>
       )}
 
       {status === 'authenticated' && !isLoading && watchlist && watchlist.length > 0 && (


### PR DESCRIPTION
## #️⃣ Issue Number

180

## 📝 변경사항

홈 화면 관심 기업 컴포넌트의 empty 상태 UI를 마이페이지와 동일하게 통일했다.

### 🎯 핵심 변경 사항 (Key Changes)

- [x] 관심 기업이 없을 때 empty UI를 마이페이지와 동일하게 수정
- [x] 홈/마이페이지 간 UI 일관성 개선



### 🖼️ 스크린샷 / 테스트 결과

<img width="407" height="226" alt="image" src="https://github.com/user-attachments/assets/e7b74a6c-8b96-4e62-b95b-7f3b99cb98b0" />

---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] 기업 페이지 검색창에서 자동완성 수정
