### PR TITLE
fix: useEffect 무한 루프 해결, 캐시 비우기

### DIFF
--- a/briefin/src/app/onboarding/page.tsx
+++ b/briefin/src/app/onboarding/page.tsx
@@ -94,7 +94,7 @@ const [submitting, setSubmitting] = useState(false);
   // 온보딩 재진입 시: 서버 watchlist를 초기 선택으로 동기화
   useEffect(() => {
     if (authStatus !== 'authenticated') return;
-    if (!watchlist) return;
+    if (!watchlist || watchlist.length === 0) return;
     if (didInteractRef.current) return;
     if (Object.keys(selected).length > 0) return;
 
@@ -198,7 +198,7 @@ const [submitting, setSubmitting] = useState(false);
                   <div
                     className="flex flex-col"
                     style={{
-                      animation: `scrollUp ${rankedCompanies.length * 1.8}s linear infinite`,
+                      animation: rankedCompanies.length > 0 ? `scrollUp ${rankedCompanies.length * 1.8}s linear infinite` : 'none',
                     }}
                   >
                     {scrollList.map((company, i) => {
@@ -351,23 +351,21 @@ const [submitting, setSubmitting] = useState(false);
             </div>
 
             {/* 선택한 기업 태그 */}
-            {selectedIds.length > 0 && (
-              <div className="mb-20pxr flex flex-wrap gap-6pxr">
-                {selectedIds.map((id) => (
-                  <button
-                    key={id}
-                    type="button"
-                    onClick={() => toggle(selected[id])}
-                    className="inline-flex items-center gap-4pxr rounded-full border border-primary bg-primary-subtle px-10pxr py-5pxr text-[12px] font-bold text-primary transition-colors hover:bg-primary-light">
-                    {selected[id]?.name ?? `#${id}`}
-                    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                      <line x1="1" y1="1" x2="9" y2="9" />
-                      <line x1="9" y1="1" x2="1" y2="9" />
-                    </svg>
-                  </button>
-                ))}
-              </div>
-            )}
+            <div className="mb-20pxr min-h-36pxr flex flex-wrap gap-6pxr">
+              {selectedIds.map((id) => (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => toggle(selected[id])}
+                  className="inline-flex items-center gap-4pxr rounded-full border border-primary bg-primary-subtle px-10pxr py-5pxr text-[12px] font-bold text-primary transition-colors hover:bg-primary-light">
+                  {selected[id]?.name ?? `#${id}`}
+                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                    <line x1="1" y1="1" x2="9" y2="9" />
+                    <line x1="9" y1="1" x2="1" y2="9" />
+                  </svg>
+                </button>
+              ))}
+            </div>
 
             {/* 기업 카드 그리드 */}
             <div className="grid grid-cols-2 gap-12pxr sm:grid-cols-3 lg:grid-cols-3 lg:gap-12pxr">

--- a/briefin/src/components/common/Header.tsx
+++ b/briefin/src/components/common/Header.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { logout as logoutApi } from '@/api/authApi';
 import { markExplicitLogout } from '@/lib/refreshSession';
 import { NAV_ITEMS } from '@/constants/header';
@@ -22,6 +23,7 @@ function getEmailFromToken(token: string): string | null {
 export default function Header() {
   const pathname = usePathname();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const authSessionVersion = useAuthSessionVersion();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [userEmail, setUserEmail] = useState<string | null>(null);
@@ -46,6 +48,7 @@ export default function Header() {
     } catch {
       /* 서버 오류여도 클라이언트 세션은 종료 */
     } finally {
+      queryClient.clear();
       markExplicitLogout();
       authStore.clear();
       setIsLoggedIn(false);

--- a/briefin/src/hooks/useAuth.ts
+++ b/briefin/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { login, signup } from '@/api/authApi';
 import { clearExplicitLogout, markMayHaveRefresh } from '@/lib/refreshSession';
@@ -6,9 +6,11 @@ import { authStore } from '@/store/authStore';
 
 export function useLogin(redirectTo?: string) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: login,
     onSuccess: (data) => {
+      queryClient.clear();
       clearExplicitLogout();
       markMayHaveRefresh();
       authStore.setAccessToken(data.accessToken);
@@ -20,9 +22,19 @@ export function useLogin(redirectTo?: string) {
 
 export function useSignup() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: signup,
-    onSuccess: () => {
+    onSuccess: async (_, variables) => {
+      queryClient.clear();
+      try {
+        const data = await login({ email: variables.email, password: variables.password });
+        clearExplicitLogout();
+        markMayHaveRefresh();
+        authStore.setAccessToken(data.accessToken);
+      } catch {
+        // 자동 로그인 실패해도 온보딩으로 이동 (사용자가 수동 로그인 가능)
+      }
       router.push('/onboarding');
     },
   });


### PR DESCRIPTION
#️⃣ Issue Number
#171 

📝 변경사항
회원가입 후 온보딩에서 기업 선택이 동작하지 않는 문제와 계정 전환 시 이전 계정 데이터가 노출되는 문제를 수정했습니다.

🎯 핵심 변경 사항 (Key Changes)
 회원가입 성공 후 자동 로그인 처리 — 온보딩에서 watchCompany API 호출 시 인증 토큰이 없어 로그인 페이지로 리다이렉트되던 문제 수정
 로그인/로그아웃/회원가입 시 queryClient.clear() 호출 — 계정 전환 시 이전 계정의 watchlist, 피드 등 캐시 데이터가 새 계정에 노출되던 문제 수정
 온보딩 useEffect 무한 루프 수정 — 신규 가입자의 빈 watchlist([])가 setSelected({})를 무한 반복 호출해 브라우저가 멈추던 문제 수정
 슬라이드 애니메이션 duration 0s 방어 — 데이터 로딩 전 rankedCompanies.length * 1.8 = 0s로 브라우저 과부하가 발생하던 문제 수정
🔍 주안점 & 리뷰 포인트
useSignup의 자동 로그인은 try/catch로 감싸 실패해도 온보딩으로는 이동합니다. 자동 로그인 실패 시 사용자가 수동으로 로그인하면 정상 동작합니다.
queryClient.clear()는 로그인·로그아웃·회원가입 세 곳 모두 적용했습니다. 같은 계정으로 재로그인하면 서버에서 데이터를 새로 fetch하므로 데이터 손실은 없습니다.
🖼️ 스크린샷 / 테스트 결과
<!-- 스크린샷 첨부 -->
🛠️ PR 유형
 🐛 버그 수정
✅ 다음 할일
 스크린샷 첨부
 코드 리뷰 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 로그아웃 시 세션 캐시를 완전히 초기화하여 세션 관리 안정성 개선
  * 온보딩 페이지 동기화 로직 최적화로 불필요한 초기화 제거

* **New Features**
  * 회원가입 완료 후 자동으로 로그인되도록 개선하여 온보딩 환경 개선

* **Refactor**
  * 로그인/회원가입 프로세스에서 캐시 초기화 추가
  * 온보딩 UI 요소 렌더링 구조 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->