### PR TITLE
feat: 기업 검색 자동완성에 티커 추가

### DIFF
--- a/briefin/src/components/companies/CompanySearchInput.tsx
+++ b/briefin/src/components/companies/CompanySearchInput.tsx
@@ -155,7 +155,14 @@ export default function CompanySearchInput({ onSearch }: { onSearch?: () => void
                           )}
                         </div>
                         <div className="min-w-0 flex-1">
-                          <p className="truncate text-[13px] font-bold text-text-primary">{company.name}</p>
+                          <div className="flex items-center gap-6pxr">
+                            <p className="truncate text-[13px] font-bold text-text-primary">{company.name}</p>
+                            {company.ticker && (
+                              <span className="shrink-0 rounded bg-surface-muted px-5pxr py-1pxr text-[10px] font-semibold text-text-muted">
+                                {company.ticker}
+                              </span>
+                            )}
+                          </div>
                           <p className="text-[11px] text-text-muted">{company.sector ?? '기타'}</p>
                         </div>
                         {company.changeRate != null && (


### PR DESCRIPTION
## #️⃣ Issue Number

182

## 📝 변경사항

기업 검색 자동완성 항목에 기업명과 함께 티커를 표시하도록 수정했다.

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 자동완성 목록에 기업명 + 티커 함께 출력
- [ ] 검색 UI 가독성 및 식별성 개선


### 🖼️ 스크린샷 / 테스트 결과

<img width="433" height="462" alt="image" src="https://github.com/user-attachments/assets/39ebea6e-2282-4d43-a553-db6685600250" />


---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] 기업 이미지 없는 경우 아이콘 수정
