### PR TITLE
fix: 기업 로고 없을 때 첫 글자표시로 통일

### DIFF
--- a/briefin/src/app/(CommonLayout)/companies/page.tsx
+++ b/briefin/src/app/(CommonLayout)/companies/page.tsx
@@ -189,21 +189,27 @@ function RecentViewedCompanies({ companies }: { companies: RecentCompany[] }) {
           const tossUrl = company.ticker
             ? `https://thumb.tossinvest.com/image/resized/96x0/https%3A%2F%2Fstatic.toss.im%2Fpng-icons%2Fsecurities%2Ficn-sec-fill-${company.ticker}.png`
             : null;
-          const logoSrc = !imgErrors[company.id] && tossUrl ? tossUrl : '/default-company.png';
+          const hasLogo = !!tossUrl && !imgErrors[company.id];
           return (
             <button
               key={company.id}
               onClick={() => router.push(`/companies/${company.id}`)}
               className="flex shrink-0 flex-col items-center gap-8pxr transition-opacity hover:opacity-70">
               <div className="relative h-80pxr w-80pxr overflow-hidden rounded-full border border-surface-border bg-surface-bg">
-                <Image
-                  src={logoSrc}
-                  alt={company.name}
-                  fill
-                  className="object-cover"
-                  unoptimized
-                  onError={() => setImgErrors(prev => ({ ...prev, [company.id]: true }))}
-                />
+                {hasLogo ? (
+                  <Image
+                    src={tossUrl!}
+                    alt={company.name}
+                    fill
+                    className="object-cover"
+                    unoptimized
+                    onError={() => setImgErrors(prev => ({ ...prev, [company.id]: true }))}
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center bg-linear-to-br from-primary to-primary-dark">
+                    <span className="text-[28px] font-black text-white">{company.name.charAt(0)}</span>
+                  </div>
+                )}
               </div>
               <p className="w-80pxr truncate text-center text-[12px] font-bold text-text-primary">{company.name}</p>
               {company.ticker && (

--- a/briefin/src/components/companies/CompanyCard.tsx
+++ b/briefin/src/components/companies/CompanyCard.tsx
@@ -16,20 +16,26 @@ export function CompanyCard({ company }: { company: CompanyCardProps }) {
   const isPositive = (company.changeRate ?? 0) >= 0;
   const router = useRouter();
   const [imgError, setImgError] = useState(false);
-  const logoSrc = !imgError && company.logoUrl ? company.logoUrl : '/default-company.png';
+  const hasLogo = !imgError && !!company.logoUrl;
 
   return (
     <div
       onClick={() => router.push(`/companies/${company.id}`)}
       className="flex cursor-pointer items-center gap-16pxr rounded-card border border-surface-border bg-surface-white px-20pxr py-16pxr transition-shadow hover:shadow-news-hover">
-      <div className="flex h-48pxr w-48pxr flex-shrink-0 items-center justify-center rounded-nav bg-primary-light overflow-hidden">
-        <Image
-          src={logoSrc}
-          alt={company.name}
-          width={48}
-          height={48}
-          onError={() => setImgError(true)}
-        />
+      <div className="flex h-48pxr w-48pxr flex-shrink-0 items-center justify-center rounded-nav overflow-hidden">
+        {hasLogo ? (
+          <Image
+            src={company.logoUrl!}
+            alt={company.name}
+            width={48}
+            height={48}
+            onError={() => setImgError(true)}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-linear-to-br from-primary to-primary-dark rounded-nav">
+            <span className="text-[20px] font-black text-white">{company.name.charAt(0)}</span>
+          </div>
+        )}
       </div>
       <div className="flex flex-col gap-4pxr">
         <div className="fonts-cardTitle">{company.name}</div>

--- a/briefin/src/components/companies/CompanyHero.tsx
+++ b/briefin/src/components/companies/CompanyHero.tsx
@@ -26,7 +26,8 @@ export default function CompanyHero({ industry, name, logoUrl, ticker, stats, is
   const tossUrl = ticker
     ? `https://thumb.tossinvest.com/image/resized/96x0/https%3A%2F%2Fstatic.toss.im%2Fpng-icons%2Fsecurities%2Ficn-sec-fill-${ticker}.png`
     : null;
-  const logoSrc = !imgError && (logoUrl || tossUrl) ? (logoUrl || tossUrl)! : '/default-company.png';
+  const resolvedLogoUrl = logoUrl || tossUrl;
+  const hasLogo = !!resolvedLogoUrl && !imgError;
 
   return (
     <div
@@ -37,14 +38,20 @@ export default function CompanyHero({ industry, name, logoUrl, ticker, stats, is
         {/* 왼쪽: 로고 + 기업명 */}
         <div className="min-w-0">
           <div className="relative h-44pxr w-44pxr shrink-0 overflow-hidden rounded-full border border-surface-border bg-surface-white md:h-56pxr md:w-56pxr">
-            <Image
-              src={logoSrc}
-              alt={name}
-              fill
-              className="object-cover"
-              unoptimized
-              onError={() => setImgError(true)}
-            />
+            {hasLogo ? (
+              <Image
+                src={resolvedLogoUrl!}
+                alt={name}
+                fill
+                className="object-cover"
+                unoptimized
+                onError={() => setImgError(true)}
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-linear-to-br from-primary to-primary-dark">
+                <span className="text-[18px] font-black text-white md:text-[22px]">{name.charAt(0)}</span>
+              </div>
+            )}
           </div>
           <h1 className="mt-10pxr text-[22px] font-black tracking-[-0.5px] text-text-primary md:mt-14pxr md:text-[32px] md:tracking-[-1px]">
             {name}


### PR DESCRIPTION
## #️⃣ Issue Number

185

## 📝 변경사항

기업 이미지가 없는 경우 default 이미지 대신 기업명 첫 글자를 표시하도록 수정했다.

### 🎯 핵심 변경 사항 (Key Changes)

- [x] 기업 이미지 fallback을 default 이미지 → 기업명 첫 글자로 변경
- [x] 기업 상세 / 검색 결과 / 최근 본 기업 영역에 동일하게 적용

### 🖼️ 스크린샷 / 테스트 결과

<img width="894" height="700" alt="image" src="https://github.com/user-attachments/assets/ac9554d0-5521-4ff6-a967-ef59eae4a64e" />
<img width="856" height="633" alt="image" src="https://github.com/user-attachments/assets/211d2844-8581-4747-828b-b4a5dfe67b21" />
<img width="457" height="528" alt="image" src="https://github.com/user-attachments/assets/af4ea193-714a-4b6a-a1fc-a6924159564e" />


---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] 기업 검색 결과 페이지 무한 스크롤


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* **회사 로고 표시 개선** - 회사 로고 이미지를 불러올 수 없거나 오류가 발생하는 경우, 회사명의 첫 글자를 그라디언트 배경과 함께 표시하는 대체 아바타로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->