### PR TITLE
fix: 등록된 공시 없을 때 멘트 수정

### DIFF
--- a/briefin/src/components/disclosure/DisclosureList.tsx
+++ b/briefin/src/components/disclosure/DisclosureList.tsx
@@ -13,7 +13,11 @@ function CategoryBadge({ category }: { category: string }) {
 export default function DisclosureList({ items, sourceLabel = 'DART 공시' }: DisclosureListProps) {
   if (!items || items.length === 0) {
     return (
-      <p className="py-40pxr text-center text-[13px] text-text-muted">해당 기업의 최근 공시가 없습니다.</p>
+      <div className="flex flex-col items-center justify-center gap-8pxr py-60pxr text-center text-text-secondary">
+        <span className="text-32pxr">📭</span>
+        <p className="fonts-body font-medium">아직 등록된 공시가 없어요</p>
+        <p className="fonts-label text-text-tertiary">새로운 공시가 등록되면 이곳에 표시됩니다.</p>
+      </div>
     );
   }
 


### PR DESCRIPTION
## #️⃣ Issue Number

189

## 📝 변경사항

기업 상세 페이지에서 공시가 없을 경우 안내 문구를 관련 뉴스 empty 상태와 동일한 스타일로 변경했다.

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 공시 empty 상태 UI를 관련 뉴스 empty UI와 동일하게 통일
- [ ] 안내 문구 스타일 및 표현 방식 일관성 개선

### 🖼️ 스크린샷 / 테스트 결과

<img width="395" height="312" alt="image" src="https://github.com/user-attachments/assets/c59e2235-3de4-4862-87f5-72a10f6a37d6" />

---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] 마이페이지 관심 기업 아이콘 통일
