### PR TITLE
fix: 관심등록 아이콘 변경/ useWatchlist 캐시 참조

### DIFF
--- a/briefin/src/app/(CommonLayout)/companies/page.tsx
+++ b/briefin/src/app/(CommonLayout)/companies/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import CompanySearchInput from '@/components/companies/CompanySearchInput';
 import { useAuthStatus } from '@/providers/AuthSessionProvider';
-import { useWatchCompany, useUnwatchCompany } from '@/hooks/useUser';
+import { useWatchlist, useWatchCompany, useUnwatchCompany } from '@/hooks/useUser';
 
 interface PopularCompany {
   id: number;
@@ -37,9 +37,10 @@ const ROW_HEIGHT = 60;
 const VISIBLE_ROWS = 6.5;
 
 
-function StarButton({ companyId, initialWatchlisted }: { companyId: number; initialWatchlisted: boolean }) {
+function StarButton({ companyId }: { companyId: number }) {
   const authStatus = useAuthStatus();
-  const [watchlisted, setWatchlisted] = useState(initialWatchlisted);
+  const { data: watchlist } = useWatchlist({ enabled: authStatus === 'authenticated' });
+  const watchlisted = watchlist?.some((c) => c.companyId === companyId) ?? false;
   const { mutate: doWatch, isPending: watching } = useWatchCompany();
   const { mutate: doUnwatch, isPending: unwatching } = useUnwatchCompany();
   const loading = watching || unwatching;
@@ -48,9 +49,9 @@ function StarButton({ companyId, initialWatchlisted }: { companyId: number; init
     e.stopPropagation();
     if (authStatus !== 'authenticated' || loading) return;
     if (watchlisted) {
-      doUnwatch(companyId, { onSuccess: () => setWatchlisted(false), onError: () => alert('요청에 실패했어요. 다시 시도해 주세요.') });
+      doUnwatch(companyId, { onError: () => alert('요청에 실패했어요. 다시 시도해 주세요.') });
     } else {
-      doWatch(companyId, { onSuccess: () => setWatchlisted(true), onError: () => alert('요청에 실패했어요. 다시 시도해 주세요.') });
+      doWatch(companyId, { onError: () => alert('요청에 실패했어요. 다시 시도해 주세요.') });
     }
   };
 
@@ -79,7 +80,7 @@ function CompanyRow({ company, rank }: { company: PopularCompany; rank: number }
     <div
       onClick={() => router.push(`/companies/${company.id}`)}
       className="flex cursor-pointer items-center gap-12pxr px-20pxr py-12pxr transition-colors hover:bg-surface-bg">
-      <StarButton companyId={company.id} initialWatchlisted={company.watchlisted ?? false} />
+      <StarButton companyId={company.id} />
       <span className={`w-18pxr shrink-0 text-[13px] font-black ${rank <= 3 ? 'text-primary-dark' : 'text-text-tertiary'}`}>
         {rank}
       </span>

--- a/briefin/src/constants/mypageIcons.tsx
+++ b/briefin/src/constants/mypageIcons.tsx
@@ -8,7 +8,7 @@ interface IconProps {
 export function WatchlistIcon({ size = 18, stroke = 'currentColor', strokeWidth = 2, fill = 'none' }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill={fill} stroke={stroke} strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
-      <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
     </svg>
   );
 }


### PR DESCRIPTION
## #️⃣ Issue Number

191

## 📝 변경사항

마이페이지 관심 기업 아이콘을 하트에서 별 아이콘으로 변경하여 기업 상세 페이지와 동일하게 통일했다.

### 🎯 핵심 변경 사항 (Key Changes)

- [ ] 관심 기업 아이콘을 하트 → 별로 변경
- [ ] 기업 상세 페이지와 아이콘 일관성 유지


---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ] 쇼프 스켈레톤 UI 바탕색 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 지켜보기 기능이 인증된 사용자의 실제 관심 목록 데이터와 동기화되도록 개선되어 더욱 정확한 상태 표시를 제공합니다.

* **스타일**
  * 관심 목록 아이콘의 시각적 디자인을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->