### PR TITLE
fix: 온보딩 ui 수정

### DIFF
--- a/briefin/src/app/onboarding/page.tsx
+++ b/briefin/src/app/onboarding/page.tsx
@@ -27,7 +27,7 @@ interface SearchResult {
 export default function OnboardingPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const [selected, setSelected] = useState<Record<string, Pick<CompanyDetail, 'id' | 'name' | 'ticker'>>>({});
+  const [selected, setSelected] = useState<Record<string, Pick<CompanyDetail, 'id' | 'name' | 'ticker'> & { logoUrl?: string }>>({});
 const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const didInteractRef = useRef(false);
@@ -106,19 +106,19 @@ const [submitting, setSubmitting] = useState(false);
     queueMicrotask(() => setSelected(next));
   }, [authStatus, selected, watchlist]);
 
-  const toggle = (company: Pick<CompanyDetail, 'id' | 'name' | 'ticker'>) => {
+  const toggle = (company: Pick<CompanyDetail, 'id' | 'name' | 'ticker'> & { logoUrl?: string }) => {
     const id = String(company.id);
     didInteractRef.current = true;
     setSelected((prev) => {
       const next = { ...prev };
       if (next[id]) delete next[id];
-      else next[id] = { id: company.id, name: company.name, ticker: company.ticker };
+      else next[id] = { id: company.id, name: company.name, ticker: company.ticker, logoUrl: company.logoUrl };
       return next;
     });
   };
 
   const handleSearchSelect = (company: SearchResult) => {
-    toggle({ id: company.id, name: company.name, ticker: company.ticker ?? '' });
+    toggle({ id: company.id, name: company.name, ticker: company.ticker ?? '', logoUrl: company.logoUrl ?? '' });
     setQ('');
     setSearchOpen(false);
   };
@@ -152,9 +152,11 @@ const [submitting, setSubmitting] = useState(false);
   };
 
   const rankedCompanies = [...popularCompanies].sort((a, b) => (b.marketCap ?? 0) - (a.marketCap ?? 0));
+  const popularIds = new Set(popularCompanies.map((c) => String(c.id)));
+  const extraSelected = selectedIds.filter((id) => !popularIds.has(id));
   const scrollList = [...rankedCompanies, ...rankedCompanies];
   const ITEM_H = 44;
-  const VISIBLE = 5;
+  const VISIBLE = 9;
 
   if (!isHydrated) return null;
 
@@ -226,22 +228,6 @@ const [submitting, setSubmitting] = useState(false);
               </div>
             </div>
 
-            <div className="mt-16pxr flex flex-col gap-10pxr">
-              <button
-                type="button"
-                onClick={goNext}
-                disabled={submitting}
-                className="h-42pxr w-full rounded-button bg-primary text-[13px] font-bold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60">
-                {submitting ? '저장 중…' : '시작하기'}
-              </button>
-              {submitError && <p className="text-[13px] font-bold text-semantic-red">{submitError}</p>}
-              <button
-                type="button"
-                onClick={handleLater}
-                className="w-full text-[13px] font-bold text-text-muted transition-colors hover:text-text-secondary focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-surface-border">
-                나중에 하기
-              </button>
-            </div>
           </aside>
 
           {/* Right content */}
@@ -386,15 +372,45 @@ const [submitting, setSubmitting] = useState(false);
                   <p className="text-[14px] font-bold text-text-primary">인기 기업 정보가 없습니다.</p>
                 </div>
               ) : (
-                popularCompanies.map((company) => (
-                  <CompanyCard
-                    key={company.id}
-                    company={company}
-                    selected={selectedIds.includes(String(company.id))}
-                    onToggle={() => toggle(company)}
-                  />
-                ))
+                <>
+                  {popularCompanies.map((company) => (
+                    <CompanyCard
+                      key={company.id}
+                      company={company}
+                      selected={selectedIds.includes(String(company.id))}
+                      onToggle={() => toggle(company)}
+                    />
+                  ))}
+                  {extraSelected.map((id) => (
+                    <CompanyCard
+                      key={id}
+                      company={{ id: Number(id), name: selected[id]?.name ?? '', ticker: selected[id]?.ticker ?? '', logoUrl: selected[id]?.logoUrl ?? '' }}
+                      selected={true}
+                      onToggle={() => toggle(selected[id])}
+                    />
+                  ))}
+                </>
               )}
+            </div>
+
+            <div className="mt-24pxr flex flex-col gap-10pxr">
+              <button
+                type="button"
+                onClick={goNext}
+                disabled={submitting}
+                className="flex h-42pxr w-full items-center rounded-button bg-primary px-16pxr text-[13px] font-bold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60">
+                <span className="flex-1 text-center">{submitting ? '저장 중…' : '시작하기'}</span>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M5 12h14M13 6l6 6-6 6" />
+                </svg>
+              </button>
+              {submitError && <p className="text-[13px] font-bold text-semantic-red">{submitError}</p>}
+              <button
+                type="button"
+                onClick={handleLater}
+                className="w-full text-[13px] font-bold text-text-muted transition-colors hover:text-text-secondary focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-surface-border">
+                나중에 하기
+              </button>
             </div>
           </section>
         </div>

--- a/briefin/src/components/onboarding/company-card.tsx
+++ b/briefin/src/components/onboarding/company-card.tsx
@@ -31,8 +31,8 @@ export default function CompanyCard({ company, selected, onToggle }: CompanyCard
       }`}
     >
       <div
-        className={`flex size-44pxr shrink-0 items-center justify-center overflow-hidden rounded-xl border border-surface-border ${
-          hasImageLogo ? 'bg-white' : 'bg-surface-muted'
+        className={`flex size-44pxr shrink-0 items-center justify-center overflow-hidden ${
+          hasImageLogo ? '' : 'bg-surface-muted rounded-xl'
         }`}
       >
         {hasImageLogo ? (


### PR DESCRIPTION
#️⃣ Issue Number
#196 

📝 변경사항
온보딩 페이지 UI 개선 및 UX 흐름을 정리했습니다.

🎯 핵심 변경 사항 (Key Changes)
 시작하기/나중에 하기 버튼을 오른쪽 섹션으로 이동
 검색으로 추가한 기업을 인기 기업과 동일한 카드 UI로 그리드에 표시
 검색 추가 기업의 logoUrl을 selected state에 저장하여 카드에 로고 정상 표시
 기업 카드 로고 이미지의 둥근 사각형 테두리 제거
 시가총액 순위 표시 개수 5개 → 9개로 확대
🔍 주안점 & 리뷰 포인트
selected state 타입에 logoUrl 필드를 추가했습니다. toggle 함수 시그니처가 변경되었으므로 해당 함수를 호출하는 모든 지점을 확인해주세요.
검색으로 추가한 기업(extraSelected)은 인기 기업 9개 ID와 비교해 필터링한 뒤 그리드 하단에 렌더링됩니다.
🖼️ 스크린샷 / 테스트 결과
<!-- 스크린샷 첨부 -->
🛠️ PR 유형
 💄 UI/UX 디자인 변경
 🐛 버그 수정
✅ 다음 할일
 스크린샷 첨부
 코드 리뷰 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 온보딩 화면에서 표시되는 인기 기업 수를 5개에서 9개로 증가했습니다.

* **개선**
  * 기업 로고 표시 및 스타일을 개선했습니다.
  * UI 레이아웃을 재구성하여 액션 버튼을 더 직관적인 위치로 이동했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->