### PR TITLE
Feat/mypage scrap infinite scroll/#197

### DIFF
--- a/briefin/src/app/(CommonLayout)/mypage/page.tsx
+++ b/briefin/src/app/(CommonLayout)/mypage/page.tsx
@@ -1,17 +1,17 @@
 'use client';
 
-import { Suspense, useState } from 'react';
+import { Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import MyPageHeader from '@/components/mypage/mypageheader';
 import AccountSection from '@/components/mypage/AccountSection';
 import WatchlistSection from '@/components/mypage/WatchlistSection';
 import SubscribedCompaniesSection from '@/components/mypage/SubscribedCompaniesSection';
 import MyPageNewsCard from '@/components/mypage/MyPageNewsCard';
+import ScrapNewsSection from '@/components/mypage/ScrapNewsSection';
 import { MyPageTab } from '@/types/mypage';
 import { TAB_FROM_QUERY, TAB_TO_QUERY, MY_PAGE_TABS } from '@/constants/mypage';
 import { WatchlistIcon, AlertIcon, ScrapIcon, RecentIcon, AccountIcon } from '@/constants/mypageIcons';
-import { useMyInfo, useScrappedNews, useRecentNews, useWatchlist } from '@/hooks/useUser';
-import { useDeleteScrapNews } from '@/hooks/useNews';
+import { useMyInfo, useRecentNews, useScrappedNews, useWatchlist } from '@/hooks/useUser';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchSubscribedCompanies } from '@/api/disclosureApi';
 import { SUBSCRIBED_COMPANIES_KEY } from '@/components/mypage/SubscribedCompaniesSection';
@@ -49,15 +49,13 @@ function MyPageContent() {
 
   const { data: userInfo } = useMyInfo();
   const { data: watchlist } = useWatchlist({ enabled: isAuthenticated });
-  const { data: scrapsData, isLoading: scrapsLoading } = useScrappedNews(1, { enabled: isAuthenticated });
+  const { data: scrapsData } = useScrappedNews(1, { enabled: isAuthenticated });
   const { data: recentData, isLoading: recentLoading } = useRecentNews(1, { enabled: isAuthenticated });
   const { data: subscribedCompanies } = useQuery({
     queryKey: SUBSCRIBED_COMPANIES_KEY,
     queryFn: fetchSubscribedCompanies,
     enabled: isAuthenticated,
   });
-  const { mutate: deleteScrap } = useDeleteScrapNews();
-  const [unscrappedIds, setUnscrappedIds] = useState<Set<number>>(new Set());
 
   const handleTabChange = (tab: MyPageTab) => {
     router.push(`/mypage?tab=${TAB_TO_QUERY[tab]}`);
@@ -152,54 +150,7 @@ function MyPageContent() {
 
           {activeTab === '관심 기업' && <WatchlistSection />}
           {activeTab === '공시 알림 기업' && <SubscribedCompaniesSection />}
-          {activeTab === '스크랩 뉴스' && (
-            <div className="flex flex-col gap-12pxr">
-              {scrapsLoading && <p className="py-40pxr text-center text-[14px] text-text-muted">불러오는 중...</p>}
-              {!scrapsLoading && (!scrapsData?.scrapList || scrapsData.scrapList.length === 0) && (
-                <div className="flex flex-col items-center gap-12pxr py-60pxr text-center">
-                  <div className="flex h-13 w-13 items-center justify-center rounded-full bg-[#E5E7EB]">
-                    <ScrapIcon size={22} stroke="#9CA3AF" />
-                  </div>
-                  <p className="fonts-body font-medium text-text-primary">스크랩한 뉴스가 없어요</p>
-                  <p className="fonts-label text-text-muted">뉴스를 읽다가 북마크 아이콘을 누르면 여기에 저장돼요.</p>
-                </div>
-              )}
-              {scrapsData?.scrapList?.map((news) => (
-                <MyPageNewsCard
-                  key={news.newsId}
-                  newsId={news.newsId}
-                  title={news.title}
-                  summary={news.summary}
-                  source={news.source}
-                  date={formatDateTime(news.scrapedAt)}
-                  thumbnailUrl={news.thumbnailUrl}
-                  topLeftSlot={
-                    <button
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        deleteScrap(news.newsId);
-                        setUnscrappedIds((prev) => new Set(prev).add(news.newsId));
-                      }}
-                      aria-label="스크랩 취소"
-                      className="shrink-0 rounded-full pb-6pxr pr-6pxr transition-colors hover:bg-surface-bg">
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill={unscrappedIds.has(news.newsId) ? 'none' : '#1E3A8A'}
-                        stroke={unscrappedIds.has(news.newsId) ? '#9CA3AF' : '#1E3A8A'}
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round">
-                        <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
-                      </svg>
-                    </button>
-                  }
-                />
-              ))}
-            </div>
-          )}
+          {activeTab === '스크랩 뉴스' && <ScrapNewsSection />}
           {activeTab === '최근 본 뉴스' && (
             <div className="flex flex-col gap-12pxr">
               {recentLoading && <p className="py-40pxr text-center text-[14px] text-text-muted">불러오는 중...</p>}

--- a/briefin/src/app/onboarding/page.tsx
+++ b/briefin/src/app/onboarding/page.tsx
@@ -23,12 +23,11 @@ interface SearchResult {
   changeRate?: number | null;
 }
 
-
 export default function OnboardingPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const [selected, setSelected] = useState<Record<string, Pick<CompanyDetail, 'id' | 'name' | 'ticker'>>>({});
-const [submitting, setSubmitting] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const didInteractRef = useRef(false);
   const authStatus = useAuthStatus();
@@ -163,7 +162,7 @@ const [submitting, setSubmitting] = useState(false);
       <div className="mx-auto w-full max-w-1600pxr px-20pxr sm:px-36pxr lg:px-130pxr">
         <div className="grid gap-16pxr lg:grid-cols-[360px_1fr] lg:gap-24pxr">
           {/* Left panel */}
-          <aside className="flex flex-col rounded-card border border-surface-border bg-surface-white p-24pxr lg:sticky lg:top-24pxr lg:h-fit lg:min-h-[560px]">
+          <aside className="flex flex-col rounded-card border border-surface-border bg-surface-white p-24pxr lg:sticky lg:top-24pxr lg:h-fit lg:min-h-560pxr">
             <div>
               <h1 className="fonts-heading2 mt-14pxr text-text-primary">관심 기업 선택</h1>
               <p className="mt-10pxr text-[14px] leading-relaxed text-text-muted">
@@ -180,10 +179,7 @@ const [submitting, setSubmitting] = useState(false);
               <div className="border-b border-surface-border px-14pxr py-10pxr">
                 <p className="text-[11px] font-bold text-text-muted">시가총액 순위</p>
               </div>
-              <div
-                className="overflow-hidden"
-                style={{ height: ITEM_H * VISIBLE }}
-              >
+              <div className="overflow-hidden" style={{ height: ITEM_H * VISIBLE }}>
                 {popularLoading ? (
                   <div className="flex flex-col">
                     {[...Array(VISIBLE)].map((_, i) => (
@@ -198,9 +194,11 @@ const [submitting, setSubmitting] = useState(false);
                   <div
                     className="flex flex-col"
                     style={{
-                      animation: rankedCompanies.length > 0 ? `scrollUp ${rankedCompanies.length * 1.8}s linear infinite` : 'none',
-                    }}
-                  >
+                      animation:
+                        rankedCompanies.length > 0
+                          ? `scrollUp ${rankedCompanies.length * 1.8}s linear infinite`
+                          : 'none',
+                    }}>
                     {scrollList.map((company, i) => {
                       const rank = (i % rankedCompanies.length) + 1;
                       const isRise = (company.changeRate ?? 0) > 0;
@@ -209,13 +207,16 @@ const [submitting, setSubmitting] = useState(false);
                         <div
                           key={`${company.id}-${i}`}
                           className="flex shrink-0 items-center gap-10pxr px-14pxr"
-                          style={{ height: ITEM_H }}
-                        >
+                          style={{ height: ITEM_H }}>
                           <span className="w-16pxr shrink-0 text-[11px] font-bold text-text-muted">{rank}</span>
-                          <span className="min-w-0 flex-1 truncate text-[13px] font-bold text-text-primary">{company.name}</span>
+                          <span className="min-w-0 flex-1 truncate text-[13px] font-bold text-text-primary">
+                            {company.name}
+                          </span>
                           {company.changeRate != null && (
-                            <span className={`shrink-0 text-[12px] font-bold ${isRise ? 'text-semantic-red' : isFall ? 'text-semantic-blue' : 'text-text-secondary'}`}>
-                              {isRise ? '+' : ''}{company.changeRate.toFixed(2)}%
+                            <span
+                              className={`shrink-0 text-[12px] font-bold ${isRise ? 'text-semantic-red' : isFall ? 'text-semantic-blue' : 'text-text-secondary'}`}>
+                              {isRise ? '+' : ''}
+                              {company.changeRate.toFixed(2)}%
                             </span>
                           )}
                         </div>
@@ -245,8 +246,7 @@ const [submitting, setSubmitting] = useState(false);
           </aside>
 
           {/* Right content */}
-          <section className="rounded-card border border-surface-border bg-surface-white p-24pxr lg:min-h-[560px]">
-
+          <section className="rounded-card border border-surface-border bg-surface-white p-24pxr lg:min-h-560pxr">
             {/* 검색창 */}
             <div ref={searchContainerRef} className="relative mb-24pxr">
               <div className="flex w-full items-center gap-8pxr rounded-input border border-surface-border bg-surface-white px-16pxr py-12pxr">
@@ -303,7 +303,9 @@ const [submitting, setSubmitting] = useState(false);
                   ) : searchResults.length === 0 ? (
                     <p className="py-16pxr text-center text-[13px] text-text-muted">검색 결과가 없어요.</p>
                   ) : (
-                    <ul className="scrollbar-hide divide-y divide-surface-border overflow-y-auto" style={{ maxHeight: 52 * 6.5 }}>
+                    <ul
+                      className="scrollbar-hide divide-y divide-surface-border overflow-y-auto"
+                      style={{ maxHeight: 52 * 6.5 }}>
                       {searchResults.map((company) => {
                         const isRise = (company.changeRate ?? 0) > 0;
                         const isFall = (company.changeRate ?? 0) < 0;
@@ -325,9 +327,7 @@ const [submitting, setSubmitting] = useState(false);
                                   />
                                 ) : (
                                   <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary to-primary-dark">
-                                    <span className="text-[13px] font-black text-white">
-                                      {company.name.charAt(0)}
-                                    </span>
+                                    <span className="text-[13px] font-black text-white">{company.name.charAt(0)}</span>
                                   </div>
                                 )}
                               </div>
@@ -336,8 +336,10 @@ const [submitting, setSubmitting] = useState(false);
                                 <p className="text-[11px] text-text-muted">{company.sector ?? '기타'}</p>
                               </div>
                               {company.changeRate != null && (
-                                <p className={`shrink-0 text-[12px] font-bold ${isRise ? 'text-semantic-red' : isFall ? 'text-semantic-blue' : 'text-text-secondary'}`}>
-                                  {isRise ? '+' : ''}{company.changeRate.toFixed(2)}%
+                                <p
+                                  className={`shrink-0 text-[12px] font-bold ${isRise ? 'text-semantic-red' : isFall ? 'text-semantic-blue' : 'text-text-secondary'}`}>
+                                  {isRise ? '+' : ''}
+                                  {company.changeRate.toFixed(2)}%
                                 </p>
                               )}
                             </button>
@@ -351,7 +353,7 @@ const [submitting, setSubmitting] = useState(false);
             </div>
 
             {/* 선택한 기업 태그 */}
-            <div className="mb-20pxr min-h-36pxr flex flex-wrap gap-6pxr">
+            <div className="mb-20pxr flex min-h-36pxr flex-wrap gap-6pxr">
               {selectedIds.map((id) => (
                 <button
                   key={id}
@@ -359,7 +361,14 @@ const [submitting, setSubmitting] = useState(false);
                   onClick={() => toggle(selected[id])}
                   className="inline-flex items-center gap-4pxr rounded-full border border-primary bg-primary-subtle px-10pxr py-5pxr text-[12px] font-bold text-primary transition-colors hover:bg-primary-light">
                   {selected[id]?.name ?? `#${id}`}
-                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <svg
+                    width="10"
+                    height="10"
+                    viewBox="0 0 10 10"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round">
                     <line x1="1" y1="1" x2="9" y2="9" />
                     <line x1="9" y1="1" x2="1" y2="9" />
                   </svg>
@@ -374,7 +383,7 @@ const [submitting, setSubmitting] = useState(false);
                   <div
                     key={`skeleton-${i}`}
                     className="flex h-80pxr w-full items-center rounded-xl border border-surface-border bg-surface-bg px-16pxr">
-                    <div className="size-[44px] animate-pulse rounded-xl bg-surface-border" />
+                    <div className="size-44pxr animate-pulse rounded-xl bg-surface-border" />
                     <div className="ml-12pxr flex-1 space-y-6pxr">
                       <div className="h-12pxr w-24 animate-pulse rounded bg-surface-border" />
                       <div className="h-10pxr w-16 animate-pulse rounded bg-surface-border" />

--- a/briefin/src/app/onboarding/page.tsx
+++ b/briefin/src/app/onboarding/page.tsx
@@ -23,12 +23,11 @@ interface SearchResult {
   changeRate?: number | null;
 }
 
-
 export default function OnboardingPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const [selected, setSelected] = useState<Record<string, Pick<CompanyDetail, 'id' | 'name' | 'ticker'>>>({});
-const [submitting, setSubmitting] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const didInteractRef = useRef(false);
   const authStatus = useAuthStatus();
@@ -92,19 +91,19 @@ const [submitting, setSubmitting] = useState(false);
   const selectedIds = Object.keys(selected);
 
   // 온보딩 재진입 시: 서버 watchlist를 초기 선택으로 동기화
-  useEffect(() => {
-    if (authStatus !== 'authenticated') return;
-    if (!watchlist || watchlist.length === 0) return;
-    if (didInteractRef.current) return;
-    if (Object.keys(selected).length > 0) return;
+  // useEffect(() => {
+  //   if (authStatus !== 'authenticated') return;
+  //   if (!watchlist || watchlist.length === 0) return;
+  //   if (didInteractRef.current) return;
+  //   if (Object.keys(selected).length > 0) return;
 
-    const next: Record<string, Pick<CompanyDetail, 'id' | 'name' | 'ticker'>> = {};
-    for (const c of watchlist) {
-      const id = String(c.companyId);
-      next[id] = { id: c.companyId, name: c.companyName ?? c.name ?? '', ticker: c.ticker };
-    }
-    queueMicrotask(() => setSelected(next));
-  }, [authStatus, selected, watchlist]);
+  //   const next: Record<string, Pick<CompanyDetail, 'id' | 'name' | 'ticker'>> = {};
+  //   for (const c of watchlist) {
+  //     const id = String(c.companyId);
+  //     next[id] = { id: c.companyId, name: c.companyName ?? c.name ?? '', ticker: c.ticker };
+  //   }
+  //   queueMicrotask(() => setSelected(next));
+  // }, [authStatus, selected, watchlist]);
 
   const toggle = (company: Pick<CompanyDetail, 'id' | 'name' | 'ticker'>) => {
     const id = String(company.id);
@@ -180,10 +179,7 @@ const [submitting, setSubmitting] = useState(false);
               <div className="border-b border-surface-border px-14pxr py-10pxr">
                 <p className="text-[11px] font-bold text-text-muted">시가총액 순위</p>
               </div>
-              <div
-                className="overflow-hidden"
-                style={{ height: ITEM_H * VISIBLE }}
-              >
+              <div className="overflow-hidden" style={{ height: ITEM_H * VISIBLE }}>
                 {popularLoading ? (
                   <div className="flex flex-col">
                     {[...Array(VISIBLE)].map((_, i) => (
@@ -198,9 +194,11 @@ const [submitting, setSubmitting] = useState(false);
                   <div
                     className="flex flex-col"
                     style={{
-                      animation: rankedCompanies.length > 0 ? `scrollUp ${rankedCompanies.length * 1.8}s linear infinite` : 'none',
-                    }}
-                  >
+                      animation:
+                        rankedCompanies.length > 0
+                          ? `scrollUp ${rankedCompanies.length * 1.8}s linear infinite`
+                          : 'none',
+                    }}>
                     {scrollList.map((company, i) => {
                       const rank = (i % rankedCompanies.length) + 1;
                       const isRise = (company.changeRate ?? 0) > 0;
@@ -209,13 +207,16 @@ const [submitting, setSubmitting] = useState(false);
                         <div
                           key={`${company.id}-${i}`}
                           className="flex shrink-0 items-center gap-10pxr px-14pxr"
-                          style={{ height: ITEM_H }}
-                        >
+                          style={{ height: ITEM_H }}>
                           <span className="w-16pxr shrink-0 text-[11px] font-bold text-text-muted">{rank}</span>
-                          <span className="min-w-0 flex-1 truncate text-[13px] font-bold text-text-primary">{company.name}</span>
+                          <span className="min-w-0 flex-1 truncate text-[13px] font-bold text-text-primary">
+                            {company.name}
+                          </span>
                           {company.changeRate != null && (
-                            <span className={`shrink-0 text-[12px] font-bold ${isRise ? 'text-semantic-red' : isFall ? 'text-semantic-blue' : 'text-text-secondary'}`}>
-                              {isRise ? '+' : ''}{company.changeRate.toFixed(2)}%
+                            <span
+                              className={`shrink-0 text-[12px] font-bold ${isRise ? 'text-semantic-red' : isFall ? 'text-semantic-blue' : 'text-text-secondary'}`}>
+                              {isRise ? '+' : ''}
+                              {company.changeRate.toFixed(2)}%
                             </span>
                           )}
                         </div>
@@ -246,7 +247,6 @@ const [submitting, setSubmitting] = useState(false);
 
           {/* Right content */}
           <section className="rounded-card border border-surface-border bg-surface-white p-24pxr lg:min-h-[560px]">
-
             {/* 검색창 */}
             <div ref={searchContainerRef} className="relative mb-24pxr">
               <div className="flex w-full items-center gap-8pxr rounded-input border border-surface-border bg-surface-white px-16pxr py-12pxr">
@@ -303,7 +303,9 @@ const [submitting, setSubmitting] = useState(false);
                   ) : searchResults.length === 0 ? (
                     <p className="py-16pxr text-center text-[13px] text-text-muted">검색 결과가 없어요.</p>
                   ) : (
-                    <ul className="scrollbar-hide divide-y divide-surface-border overflow-y-auto" style={{ maxHeight: 52 * 6.5 }}>
+                    <ul
+                      className="scrollbar-hide divide-y divide-surface-border overflow-y-auto"
+                      style={{ maxHeight: 52 * 6.5 }}>
                       {searchResults.map((company) => {
                         const isRise = (company.changeRate ?? 0) > 0;
                         const isFall = (company.changeRate ?? 0) < 0;
@@ -325,9 +327,7 @@ const [submitting, setSubmitting] = useState(false);
                                   />
                                 ) : (
                                   <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary to-primary-dark">
-                                    <span className="text-[13px] font-black text-white">
-                                      {company.name.charAt(0)}
-                                    </span>
+                                    <span className="text-[13px] font-black text-white">{company.name.charAt(0)}</span>
                                   </div>
                                 )}
                               </div>
@@ -336,8 +336,10 @@ const [submitting, setSubmitting] = useState(false);
                                 <p className="text-[11px] text-text-muted">{company.sector ?? '기타'}</p>
                               </div>
                               {company.changeRate != null && (
-                                <p className={`shrink-0 text-[12px] font-bold ${isRise ? 'text-semantic-red' : isFall ? 'text-semantic-blue' : 'text-text-secondary'}`}>
-                                  {isRise ? '+' : ''}{company.changeRate.toFixed(2)}%
+                                <p
+                                  className={`shrink-0 text-[12px] font-bold ${isRise ? 'text-semantic-red' : isFall ? 'text-semantic-blue' : 'text-text-secondary'}`}>
+                                  {isRise ? '+' : ''}
+                                  {company.changeRate.toFixed(2)}%
                                 </p>
                               )}
                             </button>
@@ -351,7 +353,7 @@ const [submitting, setSubmitting] = useState(false);
             </div>
 
             {/* 선택한 기업 태그 */}
-            <div className="mb-20pxr min-h-36pxr flex flex-wrap gap-6pxr">
+            <div className="mb-20pxr flex min-h-36pxr flex-wrap gap-6pxr">
               {selectedIds.map((id) => (
                 <button
                   key={id}
@@ -359,7 +361,14 @@ const [submitting, setSubmitting] = useState(false);
                   onClick={() => toggle(selected[id])}
                   className="inline-flex items-center gap-4pxr rounded-full border border-primary bg-primary-subtle px-10pxr py-5pxr text-[12px] font-bold text-primary transition-colors hover:bg-primary-light">
                   {selected[id]?.name ?? `#${id}`}
-                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <svg
+                    width="10"
+                    height="10"
+                    viewBox="0 0 10 10"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round">
                     <line x1="1" y1="1" x2="9" y2="9" />
                     <line x1="9" y1="1" x2="1" y2="9" />
                   </svg>

--- a/briefin/src/app/onboarding/page.tsx
+++ b/briefin/src/app/onboarding/page.tsx
@@ -26,13 +26,8 @@ interface SearchResult {
 export default function OnboardingPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
-<<<<<<< HEAD
   const [selected, setSelected] = useState<Record<string, Pick<CompanyDetail, 'id' | 'name' | 'ticker'>>>({});
   const [submitting, setSubmitting] = useState(false);
-=======
-  const [selected, setSelected] = useState<Record<string, Pick<CompanyDetail, 'id' | 'name' | 'ticker'> & { logoUrl?: string }>>({});
-const [submitting, setSubmitting] = useState(false);
->>>>>>> 5ab24efadd6d2d1b6f80226355ab1650f02cdb35
   const [submitError, setSubmitError] = useState<string | null>(null);
   const didInteractRef = useRef(false);
   const authStatus = useAuthStatus();
@@ -233,7 +228,6 @@ const [submitting, setSubmitting] = useState(false);
                 )}
               </div>
             </div>
-
           </aside>
 
           {/* Right content */}
@@ -398,7 +392,12 @@ const [submitting, setSubmitting] = useState(false);
                   {extraSelected.map((id) => (
                     <CompanyCard
                       key={id}
-                      company={{ id: Number(id), name: selected[id]?.name ?? '', ticker: selected[id]?.ticker ?? '', logoUrl: selected[id]?.logoUrl ?? '' }}
+                      company={{
+                        id: Number(id),
+                        name: selected[id]?.name ?? '',
+                        ticker: selected[id]?.ticker ?? '',
+                        logoUrl: selected[id]?.logoUrl ?? '',
+                      }}
                       selected={true}
                       onToggle={() => toggle(selected[id])}
                     />
@@ -414,7 +413,15 @@ const [submitting, setSubmitting] = useState(false);
                 disabled={submitting}
                 className="flex h-42pxr w-full items-center rounded-button bg-primary px-16pxr text-[13px] font-bold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60">
                 <span className="flex-1 text-center">{submitting ? '저장 중…' : '시작하기'}</span>
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round">
                   <path d="M5 12h14M13 6l6 6-6 6" />
                 </svg>
               </button>

--- a/briefin/src/components/mypage/ScrapNewsSection.tsx
+++ b/briefin/src/components/mypage/ScrapNewsSection.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useRef, useEffect, useState, useCallback } from 'react';
+import MyPageNewsCard from '@/components/mypage/MyPageNewsCard';
+import { ScrapIcon } from '@/constants/mypageIcons';
+import { fetchScrappedNews } from '@/api/userApi';
+import { useDeleteScrapNews } from '@/hooks/useNews';
+import { formatDateTime } from '@/utils/date';
+import type { ScrapedNews } from '@/types/mypage';
+
+const PAGE_SIZE = 10;
+
+export default function ScrapNewsSection() {
+  const [items, setItems] = useState<ScrapedNews[]>([]);
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [unscrappedIds, setUnscrappedIds] = useState<Set<number>>(new Set());
+
+  const pageRef = useRef(1);
+  const isFetchingRef = useRef(false);
+  const hasMoreRef = useRef(false);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const { mutate: deleteScrap } = useDeleteScrapNews();
+
+  const fetchPage = useCallback(async (page: number) => {
+    if (isFetchingRef.current) return;
+    isFetchingRef.current = true;
+    if (page === 1) setInitialLoading(true);
+    else setLoadingMore(true);
+    try {
+      const data = await fetchScrappedNews(page, PAGE_SIZE);
+      const total = data.totalCount ?? 0;
+      setItems((prev) => (page === 1 ? (data.scrapList ?? []) : [...prev, ...(data.scrapList ?? [])]));
+      pageRef.current = page;
+      hasMoreRef.current = page * PAGE_SIZE < total;
+    } catch {
+      if (page === 1) setItems([]);
+    } finally {
+      isFetchingRef.current = false;
+      if (page === 1) setInitialLoading(false);
+      else setLoadingMore(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPage(1);
+  }, [fetchPage]);
+
+  // sentinel은 항상 DOM에 존재해야 observer가 마운트 시 감지 가능
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMoreRef.current && !isFetchingRef.current) {
+          fetchPage(pageRef.current + 1);
+        }
+      },
+      { threshold: 0 },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [fetchPage]);
+
+  return (
+    <div className="flex flex-col gap-12pxr">
+      {initialLoading && (
+        <>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="animate-pulse rounded-card border border-surface-border bg-surface-white p-16pxr">
+              <div className="mb-8pxr h-4 w-3/4 rounded bg-gray-200" />
+              <div className="h-3 w-1/2 rounded bg-gray-200" />
+            </div>
+          ))}
+        </>
+      )}
+
+      {!initialLoading && items.length === 0 && (
+        <div className="flex flex-col items-center gap-12pxr py-60pxr text-center">
+          <div className="flex h-13 w-13 items-center justify-center rounded-full bg-[#E5E7EB]">
+            <ScrapIcon size={22} stroke="#9CA3AF" />
+          </div>
+          <p className="fonts-body font-medium text-text-primary">스크랩한 뉴스가 없어요</p>
+          <p className="fonts-label text-text-muted">뉴스를 읽다가 북마크 아이콘을 누르면 여기에 저장돼요.</p>
+        </div>
+      )}
+
+      {items.map((news) => (
+        <MyPageNewsCard
+          key={news.newsId}
+          newsId={news.newsId}
+          title={news.title}
+          summary={news.summary}
+          source={news.source}
+          date={formatDateTime(news.scrapedAt)}
+          thumbnailUrl={news.thumbnailUrl}
+          topLeftSlot={
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                deleteScrap(news.newsId, {
+                  onSuccess: () => {
+                    setItems((prev) => prev.filter((n) => n.newsId !== news.newsId));
+                  },
+                });
+                setUnscrappedIds((prev) => new Set(prev).add(news.newsId));
+              }}
+              aria-label="스크랩 취소"
+              className="shrink-0 rounded-full pb-6pxr pr-6pxr transition-colors hover:bg-surface-bg">
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill={unscrappedIds.has(news.newsId) ? 'none' : '#1E3A8A'}
+                stroke={unscrappedIds.has(news.newsId) ? '#9CA3AF' : '#1E3A8A'}
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round">
+                <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+              </svg>
+            </button>
+          }
+        />
+      ))}
+
+      {loadingMore && (
+        <>
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div key={i} className="animate-pulse rounded-card border border-surface-border bg-surface-white p-16pxr">
+              <div className="mb-8pxr h-4 w-3/4 rounded bg-gray-200" />
+              <div className="h-3 w-1/2 rounded bg-gray-200" />
+            </div>
+          ))}
+        </>
+      )}
+
+      {/* sentinel: 항상 DOM에 존재해야 IntersectionObserver가 감지 가능 */}
+      <div ref={sentinelRef} className="h-1" />
+    </div>
+  );
+}

--- a/briefin/src/components/news/NewsCard.tsx
+++ b/briefin/src/components/news/NewsCard.tsx
@@ -1,73 +1,132 @@
 'use client';
 
+import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import Label from '../common/Label';
 import { NewsCardProps } from '@/types/news';
+import { useScrapNews, useDeleteScrapNews } from '@/hooks/useNews';
+import { useAuthStatus } from '@/providers/AuthSessionProvider';
+import { ApiError } from '@/api/client';
+import { useQueryClient } from '@tanstack/react-query';
+import type { ScrapedNews } from '@/types/mypage';
 
 export default function NewsCard({ news }: NewsCardProps) {
-  const { id, source, time, title, summary, categories, companies, thumbnailUrl } = news;
+  const { id, source, time, title, summary, categories, companies, thumbnailUrl, isScraped } = news;
+
+  const queryClient = useQueryClient();
+  const cachedScraps = queryClient.getQueryData<{ scrapList: ScrapedNews[]; totalCount: number }>(['user', 'scraps', 1]);
+  const isInCache = cachedScraps?.scrapList?.some((s) => String(s.newsId) === String(id)) ?? false;
+  const [scrapped, setScrapped] = useState(isScraped ?? isInCache);
+
+  const authStatus = useAuthStatus();
+  const { mutate: doScrap, isPending: scrapping } = useScrapNews();
+  const { mutate: doDelete, isPending: deleting } = useDeleteScrapNews();
+  const isPending = scrapping || deleting;
+
+  const handleScrap = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (isPending) return;
+    if (scrapped) {
+      setScrapped(false);
+      doDelete(id, { onError: () => setScrapped(true) });
+    } else {
+      setScrapped(true);
+      doScrap(id, {
+        onError: (err) => {
+          // 409: 이미 스크랩된 상태 → scrapped 유지
+          if (err instanceof ApiError && err.status === 409) return;
+          setScrapped(false);
+        },
+      });
+    }
+  };
 
   const hasLabels = categories.length > 0 || companies.length > 0;
 
   return (
-    <Link
-      href={`/news/${id}`}
-      className="group flex max-w-1028pxr flex-col gap-10pxr rounded-card border border-surface-border bg-white px-24pxr py-22pxr sm:flex-row sm:gap-20pxr">
+    <div className="group relative max-w-1028pxr rounded-card border border-surface-border bg-white">
+      {/* 카드 전체 클릭 → 뉴스 상세 이동 */}
+      <Link href={`/news/${id}`} className="absolute inset-0 z-0" tabIndex={-1} aria-hidden />
 
-      {/* 콘텐츠 영역 */}
-      <div className="flex flex-1 flex-col gap-10pxr overflow-hidden">
+      {/* 콘텐츠: pointer-events-none으로 Link 클릭 통과, 버튼만 pointer-events-auto */}
+      <div className="pointer-events-none relative z-10 flex flex-col gap-10pxr px-24pxr py-22pxr sm:flex-row sm:gap-20pxr">
 
-        {/* 태그: 데스크탑만 */}
-        {hasLabels && (
-          <section className="flex flex-wrap gap-6pxr">
-            {categories.map((cat) => (
-              <Label key={cat} text={cat} variant="category" />
-            ))}
-            {companies.map((company) => (
-              <Label key={company} text={company} variant="company" />
-            ))}
-          </section>
-        )}
+        <div className="flex flex-1 flex-col gap-10pxr overflow-hidden">
 
-        {/* 모바일: 썸네일 + 제목 한 줄 / 데스크탑: 제목만 */}
-        <div className="flex items-start gap-12pxr sm:block">
-          {thumbnailUrl && (
-            <div className="relative h-72pxr w-100pxr shrink-0 overflow-hidden rounded-md sm:hidden">
-              <Image src={thumbnailUrl} alt="" fill className="object-cover" unoptimized />
-            </div>
+          {/* 스크랩 버튼 */}
+          {authStatus === 'authenticated' && (
+            <button
+              onClick={handleScrap}
+              disabled={isPending}
+              aria-label={scrapped ? '스크랩 취소' : '스크랩'}
+              className="pointer-events-auto self-start p-2pxr text-text-muted transition-colors hover:text-primary disabled:opacity-50">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill={scrapped ? '#1E3A8A' : 'none'}
+                stroke={scrapped ? '#1E3A8A' : 'currentColor'}
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round">
+                <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+              </svg>
+            </button>
           )}
-          <p className="fonts-cardTitle line-clamp-2 flex-1 text-text-primary transition-colors group-hover:text-primary">
-            {title}
+
+          {/* 태그 */}
+          {hasLabels && (
+            <section className="flex flex-wrap gap-6pxr">
+              {categories.map((cat) => (
+                <Label key={cat} text={cat} variant="category" />
+              ))}
+              {companies.map((company) => (
+                <Label key={company} text={company} variant="company" />
+              ))}
+            </section>
+          )}
+
+          {/* 모바일: 썸네일 + 제목 / 데스크탑: 제목만 */}
+          <div className="flex items-start gap-12pxr sm:block">
+            {thumbnailUrl && (
+              <div className="relative h-72pxr w-100pxr shrink-0 overflow-hidden rounded-md sm:hidden">
+                <Image src={thumbnailUrl} alt="" fill className="object-cover" unoptimized />
+              </div>
+            )}
+            <p className="fonts-cardTitle line-clamp-2 flex-1 text-text-primary transition-colors group-hover:text-primary">
+              {title}
+            </p>
+          </div>
+
+          {/* 요약 */}
+          {summary && summary.length > 0 && (
+            <ul className="flex flex-col gap-4pxr">
+              {summary.slice(0, 2).map((item, idx) => (
+                <li key={idx} className="fonts-label flex items-center gap-6pxr text-text-secondary">
+                  <span className="shrink-0 text-primary">•</span>
+                  <span className="line-clamp-1">{item}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {/* 언론사 + 시간 */}
+          <p className="fonts-label mt-auto flex items-center gap-4pxr pt-4pxr text-text-muted">
+            <span className="font-medium text-text-sub">{source}</span>
+            <span>·</span>
+            <span>{time}</span>
           </p>
         </div>
 
-        {/* 요약: 심플 불릿 */}
-        {summary && summary.length > 0 && (
-          <ul className="flex flex-col gap-4pxr">
-            {summary.slice(0, 2).map((item, idx) => (
-              <li key={idx} className="fonts-label flex items-center gap-6pxr text-text-secondary">
-                <span className="shrink-0 text-primary">•</span>
-                <span className="line-clamp-1">{item}</span>
-              </li>
-            ))}
-          </ul>
+        {/* 썸네일: 데스크탑만 */}
+        {thumbnailUrl && (
+          <div className="relative hidden h-100pxr w-160pxr shrink-0 self-center overflow-hidden rounded-md sm:block">
+            <Image src={thumbnailUrl} alt="" fill className="object-cover" unoptimized />
+          </div>
         )}
-
-        {/* 언론사 + 시간: 하단 바이라인 */}
-        <p className="fonts-label mt-auto flex items-center gap-4pxr pt-4pxr text-text-muted">
-          <span className="font-medium text-text-sub">{source}</span>
-          <span>·</span>
-          <span>{time}</span>
-        </p>
       </div>
-
-      {/* 썸네일: 데스크탑만 */}
-      {thumbnailUrl && (
-        <div className="relative hidden h-100pxr w-160pxr shrink-0 self-center overflow-hidden rounded-md sm:block">
-          <Image src={thumbnailUrl} alt="" fill className="object-cover" unoptimized />
-        </div>
-      )}
-    </Link>
+    </div>
   );
 }

--- a/briefin/src/components/news/NewsCard.tsx
+++ b/briefin/src/components/news/NewsCard.tsx
@@ -5,19 +5,21 @@ import Image from 'next/image';
 import Link from 'next/link';
 import Label from '../common/Label';
 import { NewsCardProps } from '@/types/news';
-import { useScrapNews, useDeleteScrapNews } from '@/hooks/useNews';
+import { useScrapNews, useDeleteScrapNews, newsKeys } from '@/hooks/useNews';
 import { useAuthStatus } from '@/providers/AuthSessionProvider';
 import { ApiError } from '@/api/client';
 import { useQueryClient } from '@tanstack/react-query';
 import type { ScrapedNews } from '@/types/mypage';
+import type { NewsDetailResponse } from '@/api/newsApi';
 
 export default function NewsCard({ news }: NewsCardProps) {
   const { id, source, time, title, summary, categories, companies, thumbnailUrl, isScraped } = news;
 
   const queryClient = useQueryClient();
+  const cachedDetail = queryClient.getQueryData<NewsDetailResponse>(newsKeys.detail(id));
   const cachedScraps = queryClient.getQueryData<{ scrapList: ScrapedNews[]; totalCount: number }>(['user', 'scraps', 1]);
   const isInCache = cachedScraps?.scrapList?.some((s) => String(s.newsId) === String(id)) ?? false;
-  const [scrapped, setScrapped] = useState(isScraped ?? isInCache);
+  const [scrapped, setScrapped] = useState(cachedDetail?.isScraped ?? isScraped ?? isInCache);
 
   const authStatus = useAuthStatus();
   const { mutate: doScrap, isPending: scrapping } = useScrapNews();

--- a/briefin/src/components/news/NewsCard.tsx
+++ b/briefin/src/components/news/NewsCard.tsx
@@ -17,7 +17,11 @@ export default function NewsCard({ news }: NewsCardProps) {
 
   const queryClient = useQueryClient();
   const cachedDetail = queryClient.getQueryData<NewsDetailResponse>(newsKeys.detail(id));
-  const cachedScraps = queryClient.getQueryData<{ scrapList: ScrapedNews[]; totalCount: number }>(['user', 'scraps', 1]);
+  const cachedScraps = queryClient.getQueryData<{ scrapList: ScrapedNews[]; totalCount: number }>([
+    'user',
+    'scraps',
+    1,
+  ]);
   const isInCache = cachedScraps?.scrapList?.some((s) => String(s.newsId) === String(id)) ?? false;
   const [scrapped, setScrapped] = useState(cachedDetail?.isScraped ?? isScraped ?? isInCache);
 
@@ -54,19 +58,17 @@ export default function NewsCard({ news }: NewsCardProps) {
 
       {/* 콘텐츠: pointer-events-none으로 Link 클릭 통과, 버튼만 pointer-events-auto */}
       <div className="pointer-events-none relative z-10 flex flex-col gap-10pxr px-24pxr py-22pxr sm:flex-row sm:gap-20pxr">
-
         <div className="flex flex-1 flex-col gap-10pxr overflow-hidden">
-
           {/* 스크랩 버튼 */}
           {authStatus === 'authenticated' && (
             <button
               onClick={handleScrap}
               disabled={isPending}
               aria-label={scrapped ? '스크랩 취소' : '스크랩'}
-              className="pointer-events-auto self-start p-2pxr text-text-muted transition-colors hover:text-primary disabled:opacity-50">
+              className="pointer-events-auto self-start p-0 text-text-muted transition-colors hover:text-primary disabled:opacity-50">
               <svg
-                width="16"
-                height="16"
+                width="20"
+                height="20"
                 viewBox="0 0 24 24"
                 fill={scrapped ? '#1E3A8A' : 'none'}
                 stroke={scrapped ? '#1E3A8A' : 'currentColor'}
@@ -84,8 +86,8 @@ export default function NewsCard({ news }: NewsCardProps) {
               {categories.map((cat) => (
                 <Label key={cat} text={cat} variant="category" />
               ))}
-              {companies.map((company) => (
-                <Label key={company} text={company} variant="company" />
+              {companies.map((company, idx) => (
+                <Label key={`${company}-${idx}`} text={company} variant="company" />
               ))}
             </section>
           )}

--- a/briefin/src/components/news/NewsDetailClient.tsx
+++ b/briefin/src/components/news/NewsDetailClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import type { NewsDetailResponse } from '@/api/newsApi';
 import { fetchRelatedNews, fetchNewsTerms } from '@/api/newsApi';
@@ -12,12 +12,15 @@ import NewsSidebar from '@/components/news/NewsSidebar';
 import NewsTimeline from '@/components/common/NewsTimeline';
 import NewsRelatedCompanies from '@/components/news/NewsRelatedCompanies';
 import NewsActions from '@/components/news/NewsActions';
-import { useNewsTimeline, useScrapNews, useDeleteScrapNews } from '@/hooks/useNews';
+import { useNewsTimeline, useScrapNews, useDeleteScrapNews, newsKeys } from '@/hooks/useNews';
 import type { NewsTimelineItem } from '@/types/timeline';
 
 export default function NewsDetailClient({ data }: { data: NewsDetailResponse }) {
   const [activeTimelineTag, setActiveTimelineTag] = useState('');
-  const [isScrapped, setIsScrapped] = useState(data.isScraped ?? false);
+
+  const queryClient = useQueryClient();
+  const cachedDetail = queryClient.getQueryData<NewsDetailResponse>(newsKeys.detail(data.newsId));
+  const [isScrapped, setIsScrapped] = useState(cachedDetail?.isScraped ?? data.isScraped ?? false);
 
   const scrapMutation = useScrapNews();
   const unscrapMutation = useDeleteScrapNews();

--- a/briefin/src/components/news/SearchContent.tsx
+++ b/briefin/src/components/news/SearchContent.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import Link from 'next/link';
 import { useEffect, useRef } from 'react';
 import { SearchComponent } from '@/components/common/SearchComponent';
 import { useSearchParams } from 'next/navigation';
 import { useNewsSearch } from '@/hooks/useNews';
+import NewsCard from '@/components/news/NewsCard';
+import NewsCardSkeleton from '@/components/news/NewsCardSkeleton';
+import { toNewsItem } from '@/api/newsApi';
 
 export default function SearchContent() {
   const searchParams = useSearchParams();
@@ -46,15 +48,9 @@ export default function SearchContent() {
       )}
 
       {isLoading && (
-        <div className="mb-30pxr mt-20pxr flex animate-pulse flex-col gap-12pxr">
+        <div className="mb-30pxr mt-20pxr flex flex-col gap-12pxr">
           {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex flex-col gap-8pxr rounded-card border border-surface-border bg-surface-white px-20pxr py-16pxr">
-              <div className="h-4 w-full rounded bg-gray-200" />
-              <div className="h-4 w-3/4 rounded bg-gray-200" />
-              <div className="h-3 w-full rounded bg-gray-200" />
-              <div className="h-3 w-1/2 rounded bg-gray-200" />
-              <div className="h-3 w-32 rounded bg-gray-200" />
-            </div>
+            <NewsCardSkeleton key={i} />
           ))}
         </div>
       )}
@@ -62,14 +58,7 @@ export default function SearchContent() {
       {!isLoading && results.length > 0 && (
         <div className="mb-30pxr mt-20pxr flex flex-col gap-12pxr">
           {results.map((news) => (
-            <Link
-              key={news.newsId}
-              href={`/news/${news.newsId}`}
-              className="flex flex-col gap-6pxr rounded-card border border-surface-border bg-surface-white px-20pxr py-16pxr transition-colors hover:bg-surface-bg">
-              <p className="text-[14px] font-bold text-text-primary">{news.title}</p>
-              {news.summary && <p className="fonts-caption line-clamp-2 text-text-muted">{news.summary}</p>}
-              <p className="fonts-caption text-text-disabled">{news.press} · {news.publishedAt}</p>
-            </Link>
+            <NewsCard key={news.newsId} news={toNewsItem(news)} />
           ))}
 
           <div ref={bottomRef} className="py-4pxr">

--- a/briefin/src/components/news/SearchContent.tsx
+++ b/briefin/src/components/news/SearchContent.tsx
@@ -39,7 +39,7 @@ export default function SearchContent() {
   return (
     <main className="relative flex h-full w-full flex-col pt-36pxr">
       <div className="fonts-heading3 mb-16pxr">뉴스</div>
-      <SearchComponent searchPath="/news/search/result" />
+      <SearchComponent searchPath="/news/search/result" defaultValue={query} />
 
       {query && (
         <div className="fonts-caption mt-20pxr text-text-muted">

--- a/briefin/src/components/reels/ReelFeedPanel.tsx
+++ b/briefin/src/components/reels/ReelFeedPanel.tsx
@@ -49,8 +49,16 @@ export default function ReelFeedPanel({
           type="button"
           onClick={() => goTo(current - 1)}
           aria-label="이전"
-          className="absolute left-10pxr top-1/2 z-20 -translate-y-1/2 flex h-36pxr w-36pxr items-center justify-center rounded-full border border-white/20 bg-white/10 text-white/70 opacity-0 backdrop-blur-sm transition-all hover:bg-white/25 hover:text-white group-hover/reelnav:opacity-100">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          className="absolute left-10pxr top-1/2 z-20 flex h-36pxr w-36pxr -translate-y-1/2 items-center justify-center rounded-full border border-white/20 bg-white/10 text-white/70 opacity-0 backdrop-blur-sm transition-all hover:bg-white/25 hover:text-white group-hover/reelnav:opacity-100">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round">
             <polyline points="15 18 9 12 15 6" />
           </svg>
         </button>
@@ -62,15 +70,27 @@ export default function ReelFeedPanel({
           type="button"
           onClick={() => goTo(current + 1)}
           aria-label="다음"
-          className="absolute right-68pxr top-1/2 z-20 -translate-y-1/2 flex h-36pxr w-36pxr items-center justify-center rounded-full border border-white/20 bg-white/10 text-white/70 opacity-0 backdrop-blur-sm transition-all hover:bg-white/25 hover:text-white group-hover/reelnav:opacity-100 sm:right-76pxr">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          className="absolute right-68pxr top-1/2 z-20 flex h-36pxr w-36pxr -translate-y-1/2 items-center justify-center rounded-full border border-white/20 bg-white/10 text-white/70 opacity-0 backdrop-blur-sm transition-all hover:bg-white/25 hover:text-white group-hover/reelnav:opacity-100 sm:right-76pxr">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round">
             <polyline points="9 18 15 12 9 6" />
           </svg>
         </button>
       )}
 
       {reels[current] && (
-        <ReelsActionRail newsId={reels[current].id} isScrapped={scrapped.has(reels[current].id)} onToggleScrap={onToggleScrap} />
+        <ReelsActionRail
+          newsId={reels[current].id}
+          isScrapped={scrapped.has(reels[current].id)}
+          onToggleScrap={onToggleScrap}
+        />
       )}
     </div>
   );

--- a/briefin/src/components/reels/ReelSlide.tsx
+++ b/briefin/src/components/reels/ReelSlide.tsx
@@ -23,7 +23,7 @@ export default function ReelSlide({ reel: r, index, activeIndex, isActive, progr
             src={r.thumbnailUrl}
             alt={r.title}
             fill
-            className="object-cover transition-transform duration-700"
+            className="object-contain transition-transform duration-700"
             unoptimized
             priority={isActive}
           />

--- a/briefin/src/hooks/useNews.ts
+++ b/briefin/src/hooks/useNews.ts
@@ -7,6 +7,7 @@ import {
   scrapNews,
   searchNews,
 } from '@/api/newsApi';
+import type { NewsDetailResponse } from '@/api/newsApi';
 
 // 쿼리 키 상수 (오타 방지)
 export const newsKeys = {
@@ -70,7 +71,20 @@ export function useScrapNews() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string | number) => scrapNews(id),
-    onSuccess: (_, id) => {
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: newsKeys.detail(id) });
+      const previous = queryClient.getQueryData<NewsDetailResponse>(newsKeys.detail(id));
+      queryClient.setQueryData<NewsDetailResponse>(newsKeys.detail(id), (old) =>
+        old ? { ...old, isScraped: true } : old,
+      );
+      return { previous };
+    },
+    onError: (_, id, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(newsKeys.detail(id), context.previous);
+      }
+    },
+    onSettled: (_, __, id) => {
       queryClient.invalidateQueries({ queryKey: newsKeys.detail(id) });
       queryClient.invalidateQueries({ queryKey: ['user', 'scraps'] });
     },
@@ -82,7 +96,20 @@ export function useDeleteScrapNews() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string | number) => deleteScrapNews(id),
-    onSuccess: (_, id) => {
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: newsKeys.detail(id) });
+      const previous = queryClient.getQueryData<NewsDetailResponse>(newsKeys.detail(id));
+      queryClient.setQueryData<NewsDetailResponse>(newsKeys.detail(id), (old) =>
+        old ? { ...old, isScraped: false } : old,
+      );
+      return { previous };
+    },
+    onError: (_, id, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(newsKeys.detail(id), context.previous);
+      }
+    },
+    onSettled: (_, __, id) => {
       queryClient.invalidateQueries({ queryKey: newsKeys.detail(id) });
       queryClient.invalidateQueries({ queryKey: ['user', 'scraps'] });
     },

--- a/briefin/src/types/news.ts
+++ b/briefin/src/types/news.ts
@@ -68,6 +68,7 @@ export interface NewsItem {
   categories: string[]; // 카테고리 태그
   companies: string[]; // 관련기업 태그
   thumbnailUrl?: string | null;
+  isScraped?: boolean;
 }
 
 export type NewsDetail = {


### PR DESCRIPTION
## #️⃣ Issue Number
- #197 

## 📝 변경사항
마이페이지 스크랩 뉴스 영역의 사용성을 개선하기 위해 무한스크롤 구조를 적용했고, 스크랩/스크랩 취소 시 뉴스 상세 캐시가 즉시 반영되도록 개선했습니다.  
또한 뉴스 검색 결과 UI를 공통 뉴스 카드 형태로 통일해 일관된 탐색 경험을 제공하도록 수정했으며, 온보딩/릴스 영역의 스타일도 함께 정리했습니다.

### 🎯 핵심 변경 사항 (Key Changes)
- [x] 마이페이지 스크랩 뉴스 영역을 `ScrapNewsSection`으로 분리하고 무한스크롤 적용
- [x] 스크랩/스크랩 취소 시 React Query `onMutate`를 활용해 뉴스 상세 캐시 즉시 업데이트
- [x] 뉴스 검색 결과를 `NewsCard` 기반으로 변경해 상세 진입 및 스크랩 UX 일관화
- [x] 뉴스 카드 클릭 영역 구조 개선 및 카드 내부 스크랩 버튼 동작 분리
- [x] 릴스 썸네일 표시 방식을 `cover` → `contain`으로 변경
- [x] 온보딩 페이지 일부 레이아웃 및 클래스명 정리

### 🖼️ 스크린샷 / 테스트 결과
- 마이페이지 > 스크랩 뉴스
  - 초기 진입 시 첫 페이지 정상 조회
  - 하단 도달 시 다음 페이지 추가 조회 확인
  - 스크랩 취소 시 리스트에서 즉시 제거되는 동작 확인
- 뉴스 상세
  - 스크랩/스크랩 취소 직후 상세 캐시 상태 즉시 반영 확인
- 뉴스 검색 결과
  - 검색 결과가 `NewsCard` UI로 노출되는 것 확인
  - 카드 클릭 시 상세 페이지 이동, 스크랩 버튼 개별 동작 확인
- 릴스
  - 썸네일이 `contain` 기준으로 잘리는 대신 원본 비율 유지하며 표시되는 것 확인

---

## 🛠️ PR 유형
- [x] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [x] 💄 UI/UX 디자인 변경
- [x] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일
- [ ] 스크랩 뉴스 무한스크롤에 에러 상태/재시도 UI 추가 검토
- [ ] 스크랩 관련 캐시 동기화 범위를 목록 쿼리까지 더 세밀하게 확장할지 검토

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 스크랩 뉴스 섹션에 무한 스크롤 기능 추가
  * 뉴스 카드에 스크랩/즐겨찾기 토글 버튼 추가 (로그인 사용자 대상)

* **Improvements**
  * 스크랩 및 삭제 작업이 즉시 화면에 반영되도록 개선
  * 뉴스 검색 결과 UI 최적화 및 일관성 강화
  * 릴 영상 썸네일 표시 방식 개선

* **Refactor**
  * 마이페이지 스크랩 뉴스 섹션을 별도 컴포넌트로 분리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->