### PR TITLE
refactor: 기업명 클릭시 기업 페이지로 라우팅

### DIFF
--- a/briefin/src/app/(CommonLayout)/disclosure/[id]/page.tsx
+++ b/briefin/src/app/(CommonLayout)/disclosure/[id]/page.tsx
@@ -60,6 +60,8 @@ export default async function DisclosureDetailPage({ params }: PageProps) {
                 date: data.disclosedAt,
                 title: data.title,
                 companyName: data.companyName,
+                companyId: data.companyId,
+                ticker: data.ticker,
               }}
             />
 

--- a/briefin/src/components/disclosure/DisclosureHeader.tsx
+++ b/briefin/src/components/disclosure/DisclosureHeader.tsx
@@ -1,3 +1,8 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
 import { DisclosureHeaderProps } from '@/types/disclosure';
 import { getCategoryLabel } from '@/constants/disclosureCategories';
 
@@ -19,13 +24,43 @@ function formatKoreanDate(dateStr: string): string {
   return `${pick('year')}년 ${pick('month')}월 ${pick('day')}일 ${pick('hour')}:${pick('minute')}`;
 }
 
-export default function DisclosureHeader({ data: { category, date, title, companyName } }: DisclosureHeaderProps) {
+function CompanyLogo({ ticker }: { ticker?: string }) {
+  const [imgError, setImgError] = useState(false);
+  const src =
+    !imgError && ticker
+      ? `https://thumb.tossinvest.com/image/resized/96x0/https%3A%2F%2Fstatic.toss.im%2Fpng-icons%2Fsecurities%2Ficn-sec-fill-${ticker}.png`
+      : null;
+
+  if (src) {
+    return (
+      <Image
+        src={src}
+        alt={ticker ?? ''}
+        width={40}
+        height={40}
+        className="rounded-full object-cover"
+        unoptimized
+        onError={() => setImgError(true)}
+      />
+    );
+  }
+  return <span className="text-[20px]">🏢</span>;
+}
+
+export default function DisclosureHeader({ data: { category, date, title, companyName, companyId, ticker } }: DisclosureHeaderProps) {
   return (
     <header className="space-y-12pxr">
       {/* 회사명 + ticker / category 배지 */}
       <div className="flex items-start justify-between gap-12pxr">
-        <div className="min-w-0">
-          {companyName && <p className="fonts-heading3 truncate font-bold text-text-primary">{companyName}</p>}
+        <div className="flex min-w-0 items-center gap-10pxr">
+          <CompanyLogo ticker={ticker} />
+          {companyName && companyId ? (
+            <Link href={`/companies/${companyId}`}>
+              <p className="fonts-heading3 truncate font-bold text-text-primary cursor-pointer">{companyName}</p>
+            </Link>
+          ) : (
+            companyName && <p className="fonts-heading3 truncate font-bold text-text-primary">{companyName}</p>
+          )}
         </div>
         {category && (
           <span className="shrink-0 rounded-pill border border-primary px-12pxr py-4pxr text-[11px] font-semibold text-primary">

--- a/briefin/src/types/disclosure.ts
+++ b/briefin/src/types/disclosure.ts
@@ -88,6 +88,7 @@ export interface DisclosureHeaderProps {
     source?: string;
     title: string;
     companyName?: string;
+    companyId?: number;
     ticker?: string;
     reportNumber?: string;
   };


### PR DESCRIPTION
## #️⃣ Issue Number

#201 

## 📝 변경사항

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 🎯 핵심 변경 사항 (Key Changes)

- [ ]
- [ ]

### 🔍 주안점 & 리뷰 포인트

기업명 클릭시 기업 페이지로 이동, 로고 추가

### 🖼️ 스크린샷 / 테스트 결과

<!--
  (Optional)
  작업 결과 만들거나 변경된 화면 스크린샷
  테스트 수행 결과 스크린샷
-->

---

## 🛠️ PR 유형

- [ ] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## ✅ 다음 할일

- [ ]
- [ ]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 공시 헤더에 회사 로고 이미지 표시 기능 추가
* 회사명을 회사 프로필 페이지로 이동하는 클릭 가능한 링크로 변경
* 로고 로드 실패 시 대체 이모지(🏢) 표시
* 회사별 고유 식별 정보 지원 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->